### PR TITLE
Fix Python 2.6 compat: no timedelta.total_seconds()

### DIFF
--- a/more_executors/retry.py
+++ b/more_executors/retry.py
@@ -9,6 +9,11 @@ import logging
 _LOG = logging.getLogger('RetryExecutor')
 
 
+def _total_seconds(td):
+    # Python 2.6 compat - equivalent of timedelta.total_seconds
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
+
 class RetryPolicy(object):
 
     def should_retry(self, attempt, return_value, exception):
@@ -188,7 +193,7 @@ class RetryExecutor(Executor):
                 # Sleep until either:
                 # - reaching the time of the nearest job, or...
                 # - woken up by condvar
-                delta = (job.when - now).total_seconds()
+                delta = _total_seconds(job.when - now)
                 _LOG.debug("No ready job.  Waiting: %s", delta)
                 self._submit_cond.wait(delta)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 PyHamcrest
 pytest
+mock; python_version < '3.3'

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -3,10 +3,11 @@
 from concurrent.futures import ThreadPoolExecutor, CancelledError, wait, FIRST_COMPLETED
 from hamcrest import assert_that, equal_to, calling, raises, instance_of, has_length
 from pytest import fixture
-import time
 from six.moves.queue import Queue
 
 from more_executors.retry import RetryExecutor, RetryPolicy
+
+from .util import assert_soon
 
 
 class SimulatedError(RuntimeError):
@@ -47,17 +48,6 @@ def test_submit_results(any_executor):
 
     results = [f.result() for f in futures]
     assert_that(results, equal_to(expected_results))
-
-
-def assert_soon(fn):
-    for _ in range(0, 100):
-        try:
-            fn()
-            break
-        except AssertionError:
-            time.sleep(0.01)
-    else:
-        fn()
 
 
 def test_submit_delayed_results(any_executor):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,61 @@
+"""Tests of the retry behavior in RetryExecutor."""
+
+from concurrent.futures import ThreadPoolExecutor
+from hamcrest import assert_that, equal_to, is_
+from pytest import fixture
+try:
+    from unittest.mock import MagicMock, call
+except ImportError:
+    from mock import MagicMock, call
+
+from more_executors.retry import RetryExecutor, ExceptionRetryPolicy
+
+from .util import assert_soon
+
+
+@fixture
+def executor():
+    policy = ExceptionRetryPolicy(
+        max_attempts=10,
+        exponent=2.0,
+        max_sleep=0.001,
+        exception_base=Exception,
+    )
+    ex = RetryExecutor(ThreadPoolExecutor(), policy)
+    yield ex
+    ex.shutdown(wait=True)
+
+
+def test_basic_retry(executor):
+    for _ in range(0, 100):
+        fn = MagicMock()
+        fn.side_effect = [
+            ValueError('error 1'),
+            ValueError('error 2'),
+            ValueError('error 3'),
+            'result',
+        ]
+
+        done_callback = MagicMock()
+
+        future = executor.submit(fn, 'a1', 'a2', kw1=1, kw2=2)
+        future.add_done_callback(done_callback)
+
+        # It should give the correct result
+        assert_that(future.result(), equal_to('result'))
+
+        # It should not have any exception
+        assert_that(future.exception(), is_(None))
+
+        # It should have called the done callback exactly once
+        # (It could still be queued for call from another thread)
+        assert_soon(lambda: done_callback.assert_called_once_with(future))
+
+        # It should have called the function 4 times with
+        # exactly the submitted args
+        fn.assert_has_calls([
+            call('a1', 'a2', kw1=1, kw2=2),
+            call('a1', 'a2', kw1=1, kw2=2),
+            call('a1', 'a2', kw1=1, kw2=2),
+            call('a1', 'a2', kw1=1, kw2=2),
+        ])

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,12 @@
+import time
+
+
+def assert_soon(fn):
+    for _ in range(0, 100):
+        try:
+            fn()
+            break
+        except AssertionError:
+            time.sleep(0.01)
+    else:
+        fn()


### PR DESCRIPTION
Includes basic autotest for retry functionality