### PR TITLE
Fix hang due to missing event set

### DIFF
--- a/more_executors/retry.py
+++ b/more_executors/retry.py
@@ -293,6 +293,7 @@ class RetryExecutor(Executor):
             self._append_job(new_job)
 
         delegate_future.add_done_callback(self._delegate_callback)
+        self._wake_thread()
 
     def _pop_job(self, job):
         with self._lock:


### PR DESCRIPTION
There was one case where jobs could be added without waking up the
thread, which could hang forever.