### PR TITLE
Introduce PollExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ extend the behavior of `Future` objects.
 
 - Futures with implicit retry
 - Futures with transformed output values
+- Futures resolved by a caller-provided polling function
 - Convenience API for creating executors
 
 See the [API documentation](https://rohanpm.github.io/more-executors/) for detailed information on usage.

--- a/more_executors/__init__.py
+++ b/more_executors/__init__.py
@@ -14,6 +14,6 @@ Compatible with Python 2.6, 2.7 and 3.x.
 This documentation was built from an unknown revision.
 """
 
-__all__ = ['map', 'retry', 'Executors']
+__all__ = ['map', 'retry', 'poll', 'Executors']
 
 from more_executors._executors import Executors

--- a/more_executors/_executors.py
+++ b/more_executors/_executors.py
@@ -3,6 +3,7 @@ from functools import partial
 
 from more_executors.map import MapExecutor
 from more_executors.retry import RetryExecutor, ExceptionRetryPolicy
+from more_executors.poll import PollExecutor
 
 
 class Executors(object):
@@ -21,6 +22,7 @@ class Executors(object):
     _WRAP_METHODS = [
         'with_retry',
         'with_map',
+        'with_poll',
     ]
 
     @classmethod
@@ -65,3 +67,13 @@ class Executors(object):
 
         - `fn`: a function used to transform each output value from the executor"""
         return cls.wrap(MapExecutor(executor, fn))
+
+    @classmethod
+    def with_poll(cls, executor, fn):
+        """Wrap an executor in a `more_executors.poll.PollExecutor`.
+
+        Submitted callables will have their output passed into the poll function.
+
+        - `fn`: a function used for polling results.  See the class documentation for
+                expected behavior from this function."""
+        return cls.wrap(PollExecutor(executor, fn))

--- a/more_executors/poll.py
+++ b/more_executors/poll.py
@@ -1,0 +1,264 @@
+"""Create futures resolved by polling with a provided function."""
+from concurrent.futures import Executor, Future
+from threading import RLock, Thread, Event
+import logging
+
+_LOG = logging.getLogger('PollExecutor')
+
+__pdoc__ = {}
+__pdoc__['PollExecutor.shutdown'] = None
+__pdoc__['PollExecutor.map'] = None
+
+
+class _PollFuture(Future):
+    def __init__(self, delegate, executor):
+        super(_PollFuture, self).__init__()
+        self._delegate = delegate
+        self._executor = executor
+        self._me_lock = RLock()
+        self._delegate.add_done_callback(self._delegate_resolved)
+
+    def _delegate_resolved(self, delegate):
+        assert delegate is self._delegate, \
+            "BUG: called with %s, expected %s" % (delegate, self._delegate)
+
+        if delegate.exception():
+            self.set_exception(delegate.exception())
+        else:
+            self._executor._register_poll(self, self._delegate)
+
+    def _clear_delegate(self):
+        with self._me_lock:
+            self._delegate = None
+
+    def set_result(self, result):
+        with self._me_lock:
+            if self.cancelled():
+                return
+            super(_PollFuture, self).set_result(result)
+
+    def set_exception(self, exception):
+        with self._me_lock:
+            if self.cancelled():
+                return
+            super(_PollFuture, self).set_exception(exception)
+
+    def running(self):
+        with self._me_lock:
+            if self._delegate:
+                return self._delegate.running()
+        # If delegate is removed, we're now polling or done.
+        return False
+
+    def cancel(self):
+        with self._me_lock:
+            if self.cancelled():
+                return True
+            if self._delegate and not self._delegate.cancel():
+                return False
+            self._executor._deregister_poll(self)
+            out = super(_PollFuture, self).cancel()
+            if out:
+                self.set_running_or_notify_cancel()
+        return out
+
+
+class PollDescriptor(object):
+    """A `PollDescriptor` represents an unresolved `Future`.
+
+    The poll function used by `more_executors.poll.PollExecutor` will be
+    invoked with a list of `PollDescriptor` objects."""
+
+    def __init__(self, result, yield_result, yield_exception):
+        """Do not construct instances of `PollDescriptor` directly."""
+
+        self.result = result
+        """The result from the delegate executor's future, which should
+        be used to drive the poll."""
+
+        self.yield_result = yield_result
+        """The poll function can call this function to make the future
+        yield the given result."""
+
+        self.yield_exception = yield_exception
+        """The poll function can call this function to make the future
+        raise the given exception."""
+
+
+class PollExecutor(Executor):
+    """Instances of `PollExecutor` submit callables to a delegate `Executor`
+    and resolve the returned futures via a provided poll function.
+
+    The poll function has the following semantics:
+
+    - It's called with a single argument, a list of zero or more
+      `more_executors.poll.PollDescriptor` objects.
+
+    - If the poll function can determine that a particular future should be
+      completed, either successfully or in error, it should call the `yield_result`
+      or `yield_exception` methods on the appropriate `PollDescriptor`.
+
+    - If the poll function raises an exception, all futures depending on that poll
+      will fail with that exception.  The poll function will be retried later.
+
+    - If the poll function returns an int or float, it is used as the delay
+      in seconds until the next poll.
+
+    ### **Example**
+
+    Consider a web service which executes tasks asynchronously, with an API like this:
+
+    * To create a task: `POST https://myservice/object/:id/publish`
+        * Returns an identifier for a task, such as `{"task_id": 123}`
+    * To get status of a single task: `GET https://myservice/tasks/:id`
+        * Returns task status, such as `{"task_id": 123, "state": "finished"}`
+    * To search for status of multiple tasks:
+      `POST https://myservice/tasks/search {"task_id": [123, 456, ...]}`
+        * Returns array of task statuses, such as
+          `[{"task_id": 123, "state": "finished"},
+            {"task_id": 456, "state": "error", "error": "..."}]`
+
+    Imagine we want to run many tasks concurrently and monitor their status.
+    Two obvious approaches include:
+
+    * We could make a function which starts a task and polls that task until
+      it completes, and have several threads run that function for different tasks.
+        * This could be easily encapsulated as a future using only the executors
+          from `concurrent.futures`, but is very inefficient - each task in progress
+          will consume a thread for polling.
+    * We could maintain a list of all outstanding tasks and implement a special-purpose
+      function to wait for all of them to complete.
+        * This is efficient as only one request is needed per poll interval, but since
+          tasks aren't represented as futures, useful features from `concurrent.futures`
+          cannot be used and different types of asynchronous work will be handled
+          inconsistently.
+
+    `PollExecutor` bridges the gap between the two approaches.  By providing a custom
+    poll function, the tasks can be monitored by one thread efficiently, while at the
+    same time allowing full usage of the API provided by `Future` objects.
+
+    In this example, the poll function would look similar to this:
+
+        def poll_tasks(poll_descriptors):
+            # Collect tasks we'll need to search for
+            task_ids = [d.result.get('task_id')
+                        for d in poll_descriptors]
+
+            # Search for status of these tasks
+            search = {"task_id": task_ids}
+            response = requests.post(
+                'https://myservice/tasks/search', json=search)
+
+            # If request failed then all outstanding futures fail
+            response.raise_for_status()
+
+            # Request passed, resolve futures accordingly
+            tasks = {task.get('task_id'): task.get('state')
+                    for task in response.json()}
+            for d in poll_descriptors:
+                task = tasks.get(d.result, {})
+                state = task.get('state')
+                if state == 'finished':
+                    d.yield_result()
+                elif state == 'error':
+                    d.yield_exception(TaskFailed())
+
+    With the poll function in place, futures could be created like this:
+
+        def publish(object_id):
+            response = requests.post(
+                'https://myservice/object/%s/publish' % object_id)
+            response.raise_for_status()
+            return response.json()
+
+        # Submit up to 4 HTTP requests at a time,
+        # and poll for the returned tasks using our poll function.
+        executor = Executors.\\
+            threadpool(max_workers=4).\\
+            with_poll(poll_fn)
+        futures = [executor.submit(publish, x)
+                   for x in (10, 20, 30)]
+
+        # Now we can use concurrent.futures API to get tasks as
+        # the poll function determines they've completed
+        for completed in as_completed(futures):
+            # ...
+    """
+
+    def __init__(self, delegate, poll_fn, default_interval=5.0):
+        """Create a new executor.
+
+        - `delegate`: `Executor` instance to which callables will be submitted
+        - `poll_fn`: a polling function used to decide when futures should be resolved;
+                     see the class documentation for the required behavior from this function
+        - `default_interval`: default interval between polls (in seconds)
+        """
+        self._delegate = delegate
+        self._default_interval = default_interval
+        self._poll_fn = poll_fn
+        self._poll_descriptors = []
+        self._poll_event = Event()
+        self._poll_thread = Thread(name='PollExecutor', target=self._poll_loop)
+        self._poll_thread.daemon = True
+        self._shutdown = False
+        self._lock = RLock()
+
+        self._poll_thread.start()
+
+    def submit(self, fn, *args, **kwargs):
+        """Submit a callable.
+
+        Returns a future which will be resolved via the poll function."""
+        delegate_future = self._delegate.submit(fn, *args, **kwargs)
+        out = _PollFuture(delegate_future, self)
+        out.add_done_callback(self._deregister_poll)
+        return out
+
+    def _register_poll(self, future, delegate_future):
+        descriptor = PollDescriptor(
+            delegate_future.result(),
+            future.set_result,
+            future.set_exception)
+        with self._lock:
+            future._clear_delegate()
+            self._poll_descriptors.append((future, descriptor))
+            self._poll_event.set()
+
+    def _deregister_poll(self, future):
+        with self._lock:
+            self._poll_descriptors = [(f, d)
+                                      for (f, d) in self._poll_descriptors
+                                      if f is not future]
+
+    def _run_poll_fn(self):
+        with self._lock:
+            descriptors = [d for (_, d) in self._poll_descriptors]
+            self._poll_event.clear()
+
+        try:
+            return self._poll_fn(descriptors)
+        except Exception as e:
+            _LOG.debug("Poll function failed: %s", e)
+            # If poll function fails, then every future
+            # depending on the poll also immediately fails.
+            [d.yield_exception(e) for d in descriptors]
+
+    def _poll_loop(self):
+        while not self._shutdown:
+            _LOG.debug("Polling...")
+
+            next_sleep = self._run_poll_fn()
+            if not (isinstance(next_sleep, int) or isinstance(next_sleep, float)):
+                next_sleep = self._default_interval
+
+            _LOG.debug("Sleeping...")
+            self._poll_event.wait(next_sleep)
+
+    def shutdown(self, wait=True):
+        self._shutdown = True
+        self._poll_event.set()
+        self._delegate.shutdown(wait)
+        if wait:
+            _LOG.debug("Join poll thread...")
+            self._poll_thread.join()
+            _LOG.debug("Joined poll thread.")

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,0 +1,230 @@
+from concurrent.futures import ThreadPoolExecutor
+from pytest import fixture
+from hamcrest import assert_that, equal_to, calling, raises, has_length
+from functools import partial
+from six.moves.queue import Queue
+from threading import Event
+
+from more_executors.poll import PollExecutor
+
+from .util import assert_soon
+
+
+@fixture
+def executor():
+    return ThreadPoolExecutor()
+
+
+def poll_tasks(tasks, poll_descriptors):
+    for descriptor in poll_descriptors:
+        task_id = descriptor.result
+        status = tasks.get(task_id)
+        if status == 'done':
+            descriptor.yield_result('done')
+        elif status == 'error':
+            descriptor.yield_exception(RuntimeError('task failed: %s' % task_id))
+
+
+def test_basic_poll(executor):
+    task_id_queue = Queue()
+    tasks = {}
+    poll_fn = partial(poll_tasks, tasks)
+    poll_executor = PollExecutor(executor, poll_fn, 0.01)
+
+    def make_task(x):
+        return '%s-%s' % (x, task_id_queue.get(True))
+
+    inputs = ['a', 'b', 'c']
+    futures = [poll_executor.submit(make_task, x) for x in inputs]
+
+    # The futures should not currently be able to progress.
+    assert_that(not any([f.done() for f in futures]))
+
+    # Allow tasks to be created.
+    task_id_queue.put('x')
+    task_id_queue.put('y')
+    task_id_queue.put('z')
+
+    # Insert some task statuses for the poll function to detect.
+    # Note that we can't guess which thread got which queue item,
+    # so let's just spam with every combination
+    tasks['a-x'] = 'done'
+    tasks['a-y'] = 'done'
+    tasks['a-z'] = 'done'
+    tasks['b-x'] = 'error'
+    tasks['b-y'] = 'error'
+    tasks['b-z'] = 'error'
+    # Leave c with no result
+
+    # Future a should become resolved
+    assert_that(futures[0].result(10), equal_to('done'))
+
+    # Future b should raise an exception
+    assert_that(calling(futures[1].result).with_args(10), raises(RuntimeError, 'task failed'))
+
+    # Future c should still be waiting
+    assert_that(not futures[2].done())
+
+
+def test_cancel_during_poll(executor):
+    task_ran = Event()
+    poll_ran = Event()
+    last_descriptors = []
+
+    def poll_fn(descriptors):
+        while last_descriptors:
+            last_descriptors.pop()
+        last_descriptors.extend(descriptors)
+        poll_ran.set()
+
+    def fn():
+        task_ran.set()
+        return 123
+
+    poll_executor = PollExecutor(executor, poll_fn, 0.01)
+    future = poll_executor.submit(fn)
+
+    # It shouldn't finish yet.
+    assert_that(not future.done())
+
+    # Wait until the delegate has definitely started executing.
+    task_ran.wait(10)
+
+    # To determine once the submitted function has completed, we can
+    # wait until 'running' is no longer true.
+    assert_soon(lambda: assert_that(not future.running()))
+
+    # Wait until next poll
+    poll_ran.clear()
+    poll_ran.wait(10.0)
+
+    # Poll function should have been passed the result of fn
+    assert_that(last_descriptors[0].result, equal_to(123))
+
+    # It should be possible to cancel the future
+    assert_that(future.cancel())
+
+    # Wait until next poll
+    poll_ran.clear()
+    poll_ran.wait(10.0)
+
+    # The cancelled future should have been removed from the
+    # descriptors passed to the poll function
+    assert_that(last_descriptors, equal_to([]))
+
+    # It should be harmless to request cancel again
+    assert_that(future.cancel())
+
+
+def test_cancel_during_poll_fn(executor):
+    queue = Queue()
+    poll_ran = Event()
+    last_descriptors = []
+
+    def poll_fn(descriptors):
+        while last_descriptors:
+            last_descriptors.pop()
+        last_descriptors.extend(descriptors)
+        poll_ran.set()
+
+        should_process = queue.get(True)
+        if should_process:
+            for descriptor in descriptors:
+                if descriptor.result == 'pass':
+                    descriptor.yield_result('pass')
+                else:
+                    descriptor.yield_exception(RuntimeError('fail'))
+
+    poll_executor = PollExecutor(executor, poll_fn, 0.01)
+    futures = [poll_executor.submit(lambda x: x, x) for x in ('pass', 'fail')]
+
+    # Wait until both futures move to polling mode.
+    def wait_two_futures():
+        poll_ran.clear()
+        queue.put(False)
+        poll_ran.wait()
+        assert_that(last_descriptors, has_length(2))
+
+    assert_soon(wait_two_futures)
+
+    # OK, now wait until the poll function is in the middle of executing
+    poll_ran.clear()
+    queue.put(False)
+    poll_ran.wait()
+
+    # Cancel the futures while poll function is in progress
+    assert_that(futures[0].cancel())
+    assert_that(futures[1].cancel())
+
+    # Now let the poll function proceed, and attempt to update the futures
+    poll_ran.clear()
+    queue.put(True)
+    poll_ran.wait()
+
+    # The futures should remain cancelled
+    assert_that(futures[0].cancelled())
+    assert_that(futures[1].cancelled())
+
+    # And they should not be passed to the poll function any more
+    assert_that(last_descriptors, equal_to([]))
+
+
+def test_poll_fail(executor):
+    task_id_queue = Queue()
+    tasks = {}
+    poll_should_fail = [False]
+    poll_ran = Event()
+
+    last_descriptors = []
+
+    def poll_fn(descriptors):
+        while last_descriptors:
+            last_descriptors.pop()
+        last_descriptors.extend(descriptors)
+        poll_ran.set()
+        if poll_should_fail[0]:
+            raise RuntimeError("simulated poll error")
+        return poll_tasks(tasks, descriptors)
+
+    poll_executor = PollExecutor(executor, poll_fn, 0.01)
+
+    def make_task(x):
+        return '%s-%s' % (x, task_id_queue.get(True))
+
+    inputs = ['a', 'b', 'c']
+    futures = [poll_executor.submit(make_task, x) for x in inputs]
+
+    # The futures should not currently be able to progress.
+    assert_that(not any([f.done() for f in futures]))
+
+    # Allow tasks to be created.
+    task_id_queue.put('x')
+    task_id_queue.put('y')
+    task_id_queue.put('z')
+
+    # Let one of the tasks complete
+    tasks['a-x'] = 'done'
+    tasks['a-y'] = 'done'
+    tasks['a-z'] = 'done'
+
+    # Future a should become resolved
+    assert_that(futures[0].result(10), equal_to('done'))
+
+    # Now set up the poll function to fail
+    poll_should_fail[0] = True
+
+    # That should make both remaining futures fail
+    assert_that(
+        calling(futures[1].result).with_args(10),
+        raises(RuntimeError, 'simulated poll error'))
+
+    assert_that(
+        calling(futures[2].result).with_args(10),
+        raises(RuntimeError, 'simulated poll error'))
+
+    # Wait for the next poll
+    poll_ran.clear()
+    poll_ran.wait(10)
+
+    # The failed futures should no longer be passed into the poll function
+    assert_that(last_descriptors, equal_to([]))


### PR DESCRIPTION
This executor resolves futures through a caller-provided poll
function.  It's intended for use in cases where an asynchronous
task can only be monitored by polling, and there's an efficient
way to poll for the status of multiple tasks at once.