### PR TITLE
Introduce CancelOnShutdownExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ extend the behavior of `Future` objects.
 ## Features
 
 - Futures with implicit retry
+- Futures with implicit cancel on executor shutdown
 - Futures with transformed output values
 - Futures resolved by a caller-provided polling function
 - Convenience API for creating executors

--- a/more_executors/__init__.py
+++ b/more_executors/__init__.py
@@ -14,6 +14,6 @@ Compatible with Python 2.6, 2.7 and 3.x.
 This documentation was built from an unknown revision.
 """
 
-__all__ = ['map', 'retry', 'poll', 'Executors']
+__all__ = ['map', 'retry', 'poll', 'cancel_on_shutdown', 'Executors']
 
 from more_executors._executors import Executors

--- a/more_executors/_executors.py
+++ b/more_executors/_executors.py
@@ -4,6 +4,7 @@ from functools import partial
 from more_executors.map import MapExecutor
 from more_executors.retry import RetryExecutor, ExceptionRetryPolicy
 from more_executors.poll import PollExecutor
+from more_executors.cancel_on_shutdown import CancelOnShutdownExecutor
 
 
 class Executors(object):
@@ -23,6 +24,7 @@ class Executors(object):
         'with_retry',
         'with_map',
         'with_poll',
+        'with_cancel_on_shutdown',
     ]
 
     @classmethod
@@ -80,3 +82,11 @@ class Executors(object):
         - `cancel_fn`: a function called when a future is cancelled.
         - `default_interval`: default interval between polls, in seconds."""
         return cls.wrap(PollExecutor(executor, fn, cancel_fn, default_interval))
+
+    @classmethod
+    def with_cancel_on_shutdown(cls, executor):
+        """Wrap an executor in a `more_executors.cancel_on_shutdown.CancelOnShutdownExecutor`.
+
+        Returned futures will have `cancel` invoked if the executor is shut down
+        before the future has completed."""
+        return cls.wrap(CancelOnShutdownExecutor(executor))

--- a/more_executors/cancel_on_shutdown.py
+++ b/more_executors/cancel_on_shutdown.py
@@ -1,0 +1,56 @@
+"""Cancel futures when executor is shut down."""
+from concurrent.futures import Executor
+from threading import RLock
+import logging
+
+__pdoc__ = {}
+__pdoc__['CancelOnShutdownExecutor.submit'] = None
+__pdoc__['CancelOnShutdownExecutor.map'] = None
+
+_LOG = logging.getLogger('CancelOnShutdownExecutor')
+
+
+class CancelOnShutdownExecutor(Executor):
+    """An `Executor` which delegates to another `Executor` and cancels all
+    futures when the executor is shut down.
+
+    This class is useful in conjunction with executors having custom cancel
+    behavior, such as `more_executors.poll.PollExecutor`.
+    """
+
+    def __init__(self, delegate):
+        """Create a new executor.
+
+        - `delegate`: `Executor` instance to which callables will be submitted
+        """
+        self._delegate = delegate
+        self._futures = set()
+        self._lock = RLock()
+        self._shutdown = False
+
+    def shutdown(self, wait=True):
+        """Shut down the executor.
+
+        All futures created by this executor which have not yet been completed
+        will have `cancel` invoked.  Note that there is no guarantee that the
+        cancel will succeed.
+        """
+        with self._lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+
+            for f in self._futures.copy():
+                cancel = f.cancel()
+                _LOG.debug("Cancel %s: %s", f, cancel)
+
+            self._delegate.shutdown(wait)
+
+    def submit(self, fn, *args, **kwargs):
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError('Cannot submit after shutdown')
+            future = self._delegate.submit(fn, *args, **kwargs)
+            self._futures.add(future)
+            future.add_done_callback(self._futures.discard)
+        return future

--- a/more_executors/map.py
+++ b/more_executors/map.py
@@ -20,6 +20,9 @@ class _MapFuture(Future):
         assert delegate is self._delegate, \
             "BUG: called with %s, expected %s" % (delegate, self._delegate)
 
+        if delegate.cancelled():
+            return
+
         ex = delegate.exception()
         if not ex:
             result = delegate.result()

--- a/tests/test_cancel_on_shutdown.py
+++ b/tests/test_cancel_on_shutdown.py
@@ -1,0 +1,83 @@
+from hamcrest import assert_that, equal_to, is_in, calling, raises, \
+                     less_than_or_equal_to, greater_than_or_equal_to
+from threading import Event
+
+from more_executors._executors import Executors
+
+
+def test_cancels():
+    proceed = Event()
+    count = 1000
+    running_count = 0
+    canceled_count = 0
+    exception_count = 0
+    completed_count = 0
+
+    futures = []
+
+    executor = Executors.thread_pool(max_workers=2).with_cancel_on_shutdown()
+    futures = [executor.submit(lambda: proceed.wait())
+               for _ in range(0, count)]
+
+    # I'm using wait=False here since otherwise it could block on the 2 threads
+    # currently in progress to finish their work items.  I can't see a way to
+    # make the test fully synchronized, and using wait=True, without deadlock.
+    executor.shutdown(wait=False)
+
+    # Now let those two threads complete (if they've started)
+    proceed.set()
+
+    # Collect status of the futures.
+    for future in futures:
+        if future.running():
+            running_count += 1
+        elif future.cancelled():
+            canceled_count += 1
+        elif future.exception():
+            exception_count += 1
+        elif future.done():
+            completed_count += 1
+
+    # No futures should have failed
+    assert_that(exception_count, equal_to(0))
+
+    # Could have been anywhere from 0..2 futures running
+    assert_that(running_count, is_in((0, 1, 2)))
+
+    # Could have been anywhere from 0..2 futures completed
+    assert_that(completed_count, is_in((0, 1, 2)))
+
+    # All others should have been cancelled
+    assert_that(canceled_count, less_than_or_equal_to(count))
+    assert_that(canceled_count, greater_than_or_equal_to(count-2))
+
+    # Harmless to call shutdown again
+    executor.shutdown()
+
+
+def test_submit_during_shutdown():
+    proceed = Event()
+    futures = []
+    submit_more_done = [False]
+
+    executor = Executors.thread_pool(max_workers=2).with_cancel_on_shutdown()
+    futures = [executor.submit(lambda: proceed.wait())
+               for _ in (1, 2, 3)]
+
+    def submit_more(f):
+        assert_that(f, equal_to(futures[2]))
+        assert_that(calling(executor.submit).with_args(lambda: None),
+                    raises(RuntimeError, 'Cannot submit after shutdown'))
+        submit_more_done[0] = True
+
+    futures[2].add_done_callback(submit_more)
+
+    # Shut it down...
+    executor.shutdown(wait=False)
+    proceed.set()
+
+    # That should have cancelled futures[2]
+    assert_that(futures[2].cancelled())
+
+    # And the tests in submit_more should have run
+    assert_that(submit_more_done[0], equal_to(True))


### PR DESCRIPTION
This executor will invoke "cancel" on every returned future when the
executor is shut down.  It's useful in combination with the cancel
function on PollExecutor - for example, to ensure that shutting down
an executor will cancel remote tasks.