### PR TITLE
Fix a race in test_broken_callback

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -180,6 +180,10 @@ def test_broken_callback(any_executor):
     results = [f.result(20.0) for f in futures]
     assert_that(results, equal_to(expected_results))
 
+    # assert_soon as there's no guarantee that callbacks
+    # are invoked before result() returns.
+    assert_soon(lambda: assert_that(callback_calls, has_length(len(futures))))
+
     for f in futures:
         assert_that(f in callback_calls)
 


### PR DESCRIPTION
Update test to cope with the fact that there's no guarantee
callbacks are invoked before future.result() returns.