### PR TITLE
Introduce SyncExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ extend the behavior of `Future` objects.
 - Futures with implicit cancel on executor shutdown
 - Futures with transformed output values
 - Futures resolved by a caller-provided polling function
+- Synchronous executor
 - Convenience API for creating executors
 
 See the [API documentation](https://rohanpm.github.io/more-executors/) for detailed information on usage.

--- a/more_executors/__init__.py
+++ b/more_executors/__init__.py
@@ -14,6 +14,6 @@ Compatible with Python 2.6, 2.7 and 3.x.
 This documentation was built from an unknown revision.
 """
 
-__all__ = ['map', 'retry', 'poll', 'cancel_on_shutdown', 'Executors']
+__all__ = ['map', 'retry', 'poll', 'sync', 'cancel_on_shutdown', 'Executors']
 
 from more_executors._executors import Executors

--- a/more_executors/_executors.py
+++ b/more_executors/_executors.py
@@ -5,6 +5,7 @@ from more_executors.map import MapExecutor
 from more_executors.retry import RetryExecutor, ExceptionRetryPolicy
 from more_executors.poll import PollExecutor
 from more_executors.cancel_on_shutdown import CancelOnShutdownExecutor
+from more_executors.sync import SyncExecutor
 
 
 class Executors(object):
@@ -48,6 +49,13 @@ class Executors(object):
     def process_pool(cls, *args, **kwargs):
         """Creates a new `concurrent.futures.ProcessPoolExecutor` with the given arguments."""
         return cls.wrap(ProcessPoolExecutor(*args, **kwargs))
+
+    @classmethod
+    def sync(cls, *args, **kwargs):
+        """Creates a new `more_executors.sync.SyncExecutor`.
+
+        Submitted functions will be immediately invoked on the calling thread."""
+        return cls.wrap(SyncExecutor(*args, **kwargs))
 
     @classmethod
     def with_retry(cls, executor, retry_policy=None):

--- a/more_executors/sync.py
+++ b/more_executors/sync.py
@@ -1,0 +1,32 @@
+"""An executor which invokes callables synchronously."""
+from concurrent.futures import Executor, Future
+
+
+__pdoc__ = {}
+__pdoc__['SyncExecutor.map'] = None
+__pdoc__['SyncExecutor.shutdown'] = None
+
+
+class SyncExecutor(Executor):
+    """An `Executor` which immediately invokes all submitted callables.
+
+    This executor is useful for testing.  With executor implementations
+    such as `ThreadPoolExecutor`, it's possible (though rare) for a future
+    to be resolved before being returned to the caller.  This may have an
+    impact on the caller's code (for example, `future.add_done_callback`
+    if called on a done future will invoke callbacks immediately in the calling
+    thread).
+
+    With this executor, that's guaranteed to always be the case.  Thus it can
+    be used to test code paths which are otherwise rarely triggered.
+    """
+    def submit(self, fn, *args, **kwargs):
+        """Immediately invokes `fn(*args, **kwargs)` and returns a future
+        with the result."""
+        future = Future()
+        try:
+            result = fn(*args, **kwargs)
+            future.set_result(result)
+        except Exception as e:
+            future.set_exception(e)
+        return future


### PR DESCRIPTION
Executors callables synchronously, in the calling thread.

Mainly for testing.  A major motivation of introducing this is to
use it from within this module's own test suite.