### PR TITLE
Use monotonic clock in RetryExecutor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
     install_requires=[
         'futures;python_version<"3"',
         'six',
+        'monotonic',
     ],
 )


### PR DESCRIPTION
Otherwise when the clock is moved forward/backward, we'll retry
at the wrong time.

Fixes #5 