### PR TITLE
Always give a timeout to thread join, to avoid uninterruptible sleep

### DIFF
--- a/more_executors/_common.py
+++ b/more_executors/_common.py
@@ -4,6 +4,20 @@ import logging
 
 _LOG = logging.getLogger('more_executors._Future')
 
+# This value should be used for any blocking waits likely to be invoked
+# from the main thread, where blocking forever is technically appropriate.
+#
+# The reason for this is that, in Python 2.x, a blocking wait with no
+# timeout (such as a thread join) is entirely uninterruptible, always
+# retrying on EINTR, which can easily lead to a process not responding
+# to anything but SIGKILL.
+#
+# Providing a timeout value - no matter what it is - causes the wait to
+# become interruptible, which is desirable.
+#
+# This value is an arbitrary choice.  100 years ought to be enough for anyone :)
+_MAX_TIMEOUT = 60*60*24*365*100
+
 
 class _Future(Future):
     # Need to reimplement some of the Future class.

--- a/more_executors/poll.py
+++ b/more_executors/poll.py
@@ -5,7 +5,7 @@ from threading import RLock, Thread, Event
 import sys
 import logging
 
-from more_executors._common import _Future
+from more_executors._common import _Future, _MAX_TIMEOUT
 
 _LOG = logging.getLogger('PollExecutor')
 
@@ -333,5 +333,5 @@ class PollExecutor(Executor):
         self._delegate.shutdown(wait)
         if wait:
             _LOG.debug("Join poll thread...")
-            self._poll_thread.join()
+            self._poll_thread.join(_MAX_TIMEOUT)
             _LOG.debug("Joined poll thread.")

--- a/more_executors/retry.py
+++ b/more_executors/retry.py
@@ -11,7 +11,7 @@ from monotonic import monotonic
 
 import logging
 
-from more_executors._common import _Future
+from more_executors._common import _Future, _MAX_TIMEOUT
 
 _LOG = logging.getLogger('RetryExecutor')
 
@@ -191,7 +191,7 @@ class RetryExecutor(Executor):
         self._delegate.shutdown(wait)
         if wait:
             _LOG.info("Waiting for thread")
-            self._submit_thread.join()
+            self._submit_thread.join(_MAX_TIMEOUT)
         _LOG.debug("Shutdown complete")
 
     @classmethod


### PR DESCRIPTION
In Python 2.x, a thread join with no timeout is uninterruptible.
This means a process could get stuck in executor shutdown such that
the process can't be killed by SIGTERM.  That's undesirable;
provide a timeout so that it's possible to interrupt.

Python 3 doesn't have this problem (tested on 3.6) - thread joins
are interruptible there.

This probably doesn't entirely fix the problem for Python 2, for
example ThreadPoolExecutor can probably still hang uninterruptably
at shutdown, but at least my code won't be contributing to the
problem...

Fixes #42