### PR TITLE
Revise TimeoutExecutor to "cancel on timeout"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ extend the behavior of `Future` objects.
 
 - Futures with implicit retry
 - Futures with implicit cancel on executor shutdown
+- Futures with implicit cancel after timeout
 - Futures with transformed output values
-- Futures with a default timeout
 - Futures resolved by a caller-provided polling function
 - Synchronous executor
 - Convenience API for creating executors
@@ -65,6 +65,9 @@ def fetch_urls(urls):
 ```
 
 ## Changelog
+
+v1.7.0
+- Revised TimeoutExecutor concept to "cancel after timeout"
 
 v1.6.0
 - Introduce TimeoutExecutor

--- a/more_executors/_executors.py
+++ b/more_executors/_executors.py
@@ -97,12 +97,12 @@ class Executors(object):
     def with_timeout(cls, executor, timeout):
         """Wrap an executor in a `more_executors.timeout.TimeoutExecutor`.
 
-        Returned futures will have a default timeout applied on calls to
-        `future.result()` and `future.exception()`.
+        Returned futures will be cancelled if they've not completed within the
+        given timeout.
 
-        - `timeout`: default timeout, in seconds (float)
+        - `timeout`: timeout value, in seconds (float)
 
-        *Since version 1.6.0*
+        *Since version 1.7.0*
         """
         return cls.wrap(TimeoutExecutor(executor, timeout))
 

--- a/more_executors/timeout.py
+++ b/more_executors/timeout.py
@@ -1,53 +1,118 @@
-"""Create futures with a default timeout."""
+"""Create futures which must complete within a timeout or be cancelled."""
 from concurrent.futures import Executor
+from threading import Event, Thread, Lock
+from collections import namedtuple
+import logging
+
+from monotonic import monotonic
 
 from more_executors.map import _MapFuture
+from more_executors._common import _MAX_TIMEOUT
 
 __pdoc__ = {}
 __pdoc__['TimeoutExecutor.map'] = None
 __pdoc__['TimeoutExecutor.shutdown'] = None
 __pdoc__['TimeoutExecutor.submit'] = None
 
+_LOG = logging.getLogger('TimeoutExecutor')
+
+_Job = namedtuple('_Job', ['future', 'delegate_future', 'deadline'])
+
 
 class _TimeoutFuture(_MapFuture):
-    def __init__(self, delegate, timeout):
+    def __init__(self, delegate):
         super(_TimeoutFuture, self).__init__(delegate, lambda x: x)
-        self._timeout = timeout
-
-    def result(self, timeout=None):
-        if timeout is None:
-            timeout = self._timeout
-        return super(_TimeoutFuture, self).result(timeout)
-
-    def exception(self, timeout=None):
-        if timeout is None:
-            timeout = self._timeout
-        return super(_TimeoutFuture, self).exception(timeout)
 
 
 class TimeoutExecutor(Executor):
-    """An `Executor` which delegates to another `Executor` while adding
-    default timeouts to each returned future.
+    """An `Executor` which delegates to another `Executor` while applying
+    a timeout to each returned future.
 
-    Note that the default timeouts only apply to the `future.result()` and
-    `future.exception()` methods.  Other methods of waiting on futures,
-    such as `concurrent.futures.wait()`, will not be affected.
+    For any futures returned by this executor, if the future hasn't
+    completed approximately within `timeout` seconds of its creation,
+    an attempt will be made to cancel the future.
 
-    *Since version 1.6.0*
+    Note that only a single attempt is made to cancel any future, and there
+    is no guarantee that this will succeed.
+
+    *Since version 1.7.0*
     """
     def __init__(self, delegate, timeout):
         """Create a new executor.
 
         - `delegate`: the delegate executor to which callables are submitted.
-        - `timeout`: the default timeout applied to any calls to `future.result()`
-                     or `future.exception()`, where a timeout has not been provided.
+        - `timeout`: timeout (in seconds) after which `future.cancel()` will be
+                     invoked on any generated future which has not completed.
         """
         self._delegate = delegate
         self._timeout = timeout
+        self._shutdown = False
+        self._jobs = []
+        self._jobs_lock = Lock()
+        self._jobs_write = Event()
+        self._job_thread = Thread(
+            name='TimeoutExecutor', target=self._job_loop)
+        self._job_thread.daemon = True
+        self._job_thread.start()
 
     def submit(self, fn, *args, **kwargs):
-        future = self._delegate.submit(fn, *args, **kwargs)
-        return _TimeoutFuture(future, self._timeout)
+        delegate_future = self._delegate.submit(fn, *args, **kwargs)
+        future = _TimeoutFuture(delegate_future)
+        future.add_done_callback(self._on_future_done)
+        job = _Job(future, delegate_future, monotonic() + self._timeout)
+        with self._jobs_lock:
+            self._jobs.append(job)
+        self._jobs_write.set()
+        return future
 
     def shutdown(self, wait=True):
+        _LOG.debug("shutdown")
+        self._shutdown = True
+        self._jobs_write.set()
         self._delegate.shutdown(wait)
+        if wait:
+            self._job_thread.join(_MAX_TIMEOUT)
+
+    def _partition_jobs(self):
+        pending = []
+        overdue = []
+        now = monotonic()
+        for job in self._jobs:
+            if job.future.done():
+                _LOG.debug("Discarding job for completed future: %s", job)
+            elif job.deadline < now:
+                overdue.append(job)
+            else:
+                pending.append(job)
+        return (pending, overdue)
+
+    def _on_future_done(self, future):
+        _LOG.debug("Waking thread for %s", future)
+        self._jobs_write.set()
+
+    def _do_cancel(self, job):
+        _LOG.debug("Attempting cancel: %s", job)
+        cancel_result = job.future.cancel()
+        _LOG.debug("Cancel of %s resulted in %s", job, cancel_result)
+
+    def _job_loop(self):
+        while not self._shutdown:
+            _LOG.debug("job loop")
+            self._jobs_write.clear()
+
+            with self._jobs_lock:
+                (pending, overdue) = self._partition_jobs()
+                self._jobs = pending
+
+            _LOG.debug("jobs: %s overdue, %s pending", len(overdue), len(pending))
+
+            for job in overdue:
+                self._do_cancel(job)
+
+            wait_time = None
+            if pending:
+                earliest = min([job.deadline for job in pending])
+                wait_time = max(earliest - monotonic(), 0)
+
+            _LOG.debug("Wait until %s", wait_time)
+            self._jobs_write.wait(wait_time)


### PR DESCRIPTION
The original concept of TimeoutExecutor was simply to apply a
default timeout on calls to result/exception.  The new concept
is instead to cancel futures which don't complete within the
timeout.

I think this makes more sense as the previous concept couldn't
work with methods such as `wait`, `as_completed`, which don't
work by calling result/exception.

The docs have been updated to pretend that TimeoutExecutor was
introduced in 1.7.0, since the semantics changed so drastically.

Closes #50