### PR TITLE
Put USE_PANDOC=1 in scripts/release instead of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ docs: .PHONY
 release: .PHONY
 	tox -e py35
 	.tox/py35/bin/pip install pypandoc
-	env USE_PANDOC=1 .tox/py35/bin/python scripts/release
+	.tox/py35/bin/python scripts/release

--- a/scripts/release
+++ b/scripts/release
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from tempfile import NamedTemporaryFile
 from subprocess import check_output, check_call
-from os import getcwd, rename
+from os import getcwd, rename, environ
 import sys
 
 
@@ -64,6 +64,7 @@ def push(release_version):
 
 
 def run():
+    environ['USE_PANDOC'] = 1
     old_version = get_version()
     if not old_version.endswith('.dev0'):
         print("Assuming resumption of interrupted release")


### PR DESCRIPTION
To ensure the docs are generated appropriately for PyPI without
having to use the Makefile.