### PR TITLE
Travis: run autotests 5 times for each configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,24 @@ branches:
     - master
 matrix:
   include:
+  # Each python version is repeated multiple times here to make flaky
+  # tests less likely to get past Travis by running them more times
   - python: "2.6"
-    env: TOX_ENV=py26
+    env: TOX_ENV=py26 ITER=1
+  - python: "2.6"
+    env: TOX_ENV=py26 ITER=2
+  - python: "2.6"
+    env: TOX_ENV=py26 ITER=3
   - python: "2.7"
-    env: TOX_ENV=py27
+    env: TOX_ENV=py27 ITER=1
+  - python: "2.7"
+    env: TOX_ENV=py27 ITER=2
+  - python: "2.7"
+    env: TOX_ENV=py27 ITER=3
+  - python: "3.5"
+    env: TOX_ENV=py35 ITER=1
+  - python: "3.5"
+    env: TOX_ENV=py35 ITER=2
   - python: "3.5"
     env: TOX_ENV=cov-travis
   - python: "3.5"


### PR DESCRIPTION
There have been a couple of times where flaky tests were merged.
Let's run autotests more times to make it less likely flaky tests
can be merged.