### PR TITLE
Improved RetryPolicy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ def fetch_urls(urls):
 
 ## Changelog
 
+### v1.10.0
+
+- Improved RetryPolicy API
+
 ### v1.9.0
 
 - Introduced ThrottleExecutor

--- a/examples/fetch-urls
+++ b/examples/fetch-urls
@@ -14,15 +14,15 @@ class LoggingRetryPolicy(RetryPolicy):
         # Inherit the behavior from the default policy
         self.policy = ExceptionRetryPolicy.new_default()
 
-    def should_retry(self, attempt, result, exception):
-        retry = self.policy.should_retry(attempt, result, exception)
+    def should_retry(self, attempt, future):
+        retry = self.policy.should_retry(attempt, future)
         if retry:
-            delay = self.sleep_time(attempt, result, exception)
-            print("Error - retry in %ss: %s" % (delay, exception))
+            delay = self.sleep_time(attempt, future)
+            print("Error - retry in %ss: %s" % (delay, future.exception()))
         return retry
 
-    def sleep_time(self, attempt, result, exception):
-        return self.policy.sleep_time(attempt, result, exception)
+    def sleep_time(self, attempt, future):
+        return self.policy.sleep_time(attempt, future)
 
 
 def get_content(response):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -207,8 +207,8 @@ def test_order(executor):
 def test_override_policy(executor):
     """Should be able to provide a custom policy by subclassing RetryPolicy."""
     class SubRetryPolicy(RetryPolicy):
-        def should_retry(self, attempt, result, exception):
-            return result < 3
+        def should_retry(self, attempt, future):
+            return future.result() < 3
 
     fn = MagicMock()
     fn.side_effect = [1, 2, 3, AssertionError("unexpected call")]


### PR DESCRIPTION
Just pass a future object rather than result/exception.
This allows the policy to notice if a future was cancelled.