### PR TITLE
tests: double timeout in test_executor

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -15,7 +15,7 @@ from more_executors._executors import Executors
 
 from .util import assert_soon
 
-TIMEOUT = 10.0
+TIMEOUT = 20.0
 
 
 class SimulatedError(RuntimeError):


### PR DESCRIPTION
The test times out every now and then in Travis.
It could be exposing a real bug, but let's try increasing the timeout
first, in case the problem is simply unfavorable scheduling.