### PR TITLE
Introduce pytest timeouts

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 PyHamcrest
 pytest >= 3.4; python_version >= '2.7'
+pytest-timeout; python_version >= '2.7'
 pytest; python_version < '2.7'
 mock; python_version < '3.3'

--- a/tox.ini
+++ b/tox.ini
@@ -49,3 +49,7 @@ commands=
 
 [flake8]
 max-line-length = 100
+
+[pytest]
+timeout = 300
+timeout_method = signal


### PR DESCRIPTION
Tests which take longer than 5 minutes should fail, hopefully
with a useful thread dump.