### PR TITLE
Fix hangs at shutdown on several executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ def fetch_urls(urls):
 
 ## Changelog
 
+### v1.11.0
+
+- Fixed hangs on executor shutdown
+
 ### v1.10.0
 
 - Improved RetryPolicy API

--- a/more_executors/poll.py
+++ b/more_executors/poll.py
@@ -297,7 +297,6 @@ class PollExecutor(Executor):
     def _run_poll_fn(self):
         with self._lock:
             descriptors = [d for (_, d) in self._poll_descriptors]
-            self._poll_event.clear()
 
         try:
             return self._poll_fn(descriptors)
@@ -317,6 +316,7 @@ class PollExecutor(Executor):
 
             self._log.debug("Sleeping...")
             self._poll_event.wait(next_sleep)
+            self._poll_event.clear()
 
     def shutdown(self, wait=True):
         self._shutdown = True

--- a/more_executors/throttle.py
+++ b/more_executors/throttle.py
@@ -80,8 +80,6 @@ class ThrottleExecutor(Executor):
 
     def _submit_loop(self):
         while not self._shutdown:
-            self._event.clear()
-
             to_submit = []
             with self._lock:
                 while self._to_submit:
@@ -99,6 +97,7 @@ class ThrottleExecutor(Executor):
                 self._do_submit(job)
 
             self._event.wait()
+            self._event.clear()
 
     def _do_submit(self, job):
         delegate_future = self._delegate.submit(job.fn, *job.args, **job.kwargs)

--- a/more_executors/timeout.py
+++ b/more_executors/timeout.py
@@ -98,7 +98,6 @@ class TimeoutExecutor(Executor):
     def _job_loop(self):
         while not self._shutdown:
             self._log.debug("job loop")
-            self._jobs_write.clear()
 
             with self._jobs_lock:
                 (pending, overdue) = self._partition_jobs()
@@ -116,3 +115,4 @@ class TimeoutExecutor(Executor):
 
             self._log.debug("Wait until %s", wait_time)
             self._jobs_write.wait(wait_time)
+            self._jobs_write.clear()


### PR DESCRIPTION
We must ensure that 'shutdown' is checked between every
event clear and wait.