### PR TITLE
Introduce FlatMapExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ extend the behavior of `Future` objects.
 - Futures with implicit retry
 - Futures with implicit cancel on executor shutdown
 - Futures with implicit cancel after timeout
-- Futures with transformed output values
+- Futures with transformed output values (sync & async)
 - Futures resolved by a caller-provided polling function
 - Throttle the number of futures running at once
 - Synchronous executor
@@ -67,6 +67,10 @@ def fetch_urls(urls):
 ```
 
 ## Changelog
+
+### v1.12.0
+
+- Introduced FlatMapExecutor
 
 ### v1.11.0
 

--- a/more_executors/__init__.py
+++ b/more_executors/__init__.py
@@ -15,5 +15,5 @@ This documentation was built from an unknown revision.
 """
 from more_executors._executors import Executors
 
-__all__ = ['asyncio', 'map', 'retry', 'poll', 'sync', 'timeout',
+__all__ = ['asyncio', 'map', 'flat_map', 'retry', 'poll', 'sync', 'timeout',
            'throttle', 'cancel_on_shutdown', 'Executors']

--- a/more_executors/_executors.py
+++ b/more_executors/_executors.py
@@ -2,6 +2,7 @@ from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from functools import partial
 
 from more_executors.map import MapExecutor
+from more_executors.flat_map import FlatMapExecutor
 from more_executors.retry import RetryExecutor
 from more_executors.poll import PollExecutor
 from more_executors.timeout import TimeoutExecutor
@@ -27,6 +28,7 @@ class Executors(object):
     _WRAP_METHODS = [
         'with_retry',
         'with_map',
+        'with_flat_map',
         'with_poll',
         'with_timeout',
         'with_throttle',
@@ -78,6 +80,17 @@ class Executors(object):
         Submitted callables will have their output transformed by the given function.
         """
         return cls.wrap(MapExecutor(executor, *args, **kwargs))
+
+    @classmethod
+    def with_flat_map(cls, executor, *args, **kwargs):
+        """Wrap an executor in a `more_executors.flat_map.FlatMapExecutor`.
+
+        Submitted callables will have their output transformed by the given
+        `Future`-producing function.
+
+        *Since version 1.12.0*
+        """
+        return cls.wrap(FlatMapExecutor(executor, *args, **kwargs))
 
     @classmethod
     def with_poll(cls, executor, *args, **kwargs):

--- a/more_executors/flat_map.py
+++ b/more_executors/flat_map.py
@@ -1,0 +1,58 @@
+"""Transform the output value of a future asynchronously."""
+
+from more_executors.map import _MapFuture, MapExecutor
+
+__pdoc__ = {}
+__pdoc__['FlatMapExecutor.shutdown'] = None
+__pdoc__['FlatMapExecutor.map'] = None
+__pdoc__['FlatMapExecutor.submit'] = """Submit a callable.
+
+The returned `Future` will have its output value transformed by the
+map function passed to this executor.
+
+- If the map function returns a `Future`, the result/exception of
+  that future will be propagated to the future returned by this function.
+- If the map function returns anything other than a `Future`, the returned
+  future will fail with a `TypeError`.
+- If the map function raises an exception, the returned future will fail
+  with that exception.
+"""
+
+
+class _FlatMapFuture(_MapFuture):
+    def __init__(self, *args, **kwargs):
+        self.__flattened = False
+        super(_FlatMapFuture, self).__init__(*args, **kwargs)
+
+    def _on_mapped(self, result):
+        if self.__flattened:
+            return super(_FlatMapFuture, self)._on_mapped(result)
+
+        # Result *must* be a future.
+        # We'd crash in set_delegate if not.
+        # Let's raise this more helpful exception prior to that.
+        if not callable(getattr(result, 'add_done_callback', None)):
+            raise TypeError(
+                "FlatMapExecutor's function did not return a Future!\n"
+                "  Function: %s\n"
+                "  Returned: %s" % (repr(self._map_fn), repr(result)))
+
+        self.__flattened = True
+        self._map_fn = lambda x: x
+        self._set_delegate(result)
+
+
+class FlatMapExecutor(MapExecutor):
+    """An `Executor` which delegates to another `Executor` while mapping
+    output values through a given `Future`-producing function.
+
+    This executor behaves like `MapExecutor`, except that the given mapping
+    function must return instances of `Future`, and the mapped future is
+    flattened into the future returned from this executor.
+    This allows chaining multiple future-producing functions into a single
+    future.
+
+    *Since version 1.12.0*
+    """
+
+    _FUTURE_CLASS = _FlatMapFuture

--- a/tests/test_flat_map.py
+++ b/tests/test_flat_map.py
@@ -1,0 +1,119 @@
+from concurrent.futures import ThreadPoolExecutor
+from pytest import fixture
+from hamcrest import assert_that, equal_to, instance_of, calling, raises
+
+from more_executors._executors import Executors
+from more_executors.flat_map import FlatMapExecutor
+
+
+@fixture
+def executor():
+    return ThreadPoolExecutor()
+
+
+def add1(x):
+    return x + 1
+
+
+def mult10(x):
+    return x * 10
+
+
+def div10by(x):
+    return 10 / x
+
+
+def test_basic_flat_map(executor):
+    flat_map_executor = FlatMapExecutor(
+        executor,
+        lambda x: executor.submit(mult10, x))
+
+    inputs = [1, 2, 3]
+    expected_result = [20, 40, 60]
+
+    futures = [flat_map_executor.submit(lambda x: x*2, x) for x in inputs]
+    results = [f.result() for f in futures]
+
+    assert_that(results, equal_to(expected_result))
+
+
+def test_flat_map_exception(executor):
+    flat_map_executor = FlatMapExecutor(
+        executor,
+        lambda x: executor.submit(div10by, x))
+
+    inputs = [1, 2, 0]
+
+    futures = [flat_map_executor.submit(lambda v: v, x) for x in inputs]
+
+    # First two should succeed and give the mapped value
+    assert_that(futures[0].result(), equal_to(10))
+    assert_that(futures[1].result(), equal_to(5))
+
+    # The third should have crashed
+    assert_that(futures[2].exception(), instance_of(ZeroDivisionError))
+    assert_that(calling(futures[2].result), raises(ZeroDivisionError))
+
+
+def test_flat_map_nofuture(executor):
+    """Executor raises TypeError if map function does not produce a Future."""
+
+    flat_map_executor = FlatMapExecutor(
+        executor,
+        lambda x: executor.submit(mult10, x) if x == 2 else mult10(x))
+
+    inputs = [1, 2, 3]
+
+    futures = [flat_map_executor.submit(lambda v: v, x) for x in inputs]
+
+    # The second future should have returned the mapped value
+    assert_that(futures[1].result(), equal_to(20))
+
+    # The others should have failed since returned value is not a Future
+    assert_that(futures[0].exception(), instance_of(TypeError))
+    assert_that(calling(futures[2].result), raises(TypeError))
+
+
+def test_chained_flat_map(executor):
+    """Chaining multiple flatmaps pass through values as expected."""
+
+    flat_map_executor = Executors.wrap(executor).\
+        with_flat_map(lambda x: executor.submit(mult10, x)).\
+        with_flat_map(lambda x: executor.submit(add1, x))
+
+    inputs = [1, 2]
+
+    futures = [flat_map_executor.submit(lambda v: v, x) for x in inputs]
+
+    # It should have produced the expected values
+    assert_that(futures[0].result(), equal_to(11))
+    assert_that(futures[1].result(), equal_to(21))
+
+
+def test_chained_flat_map_exception(executor):
+    """Executor propagates innermost exception in the case of chained flatmaps."""
+
+    my_exception = RuntimeError('testing')
+    fn2_called = []
+
+    def fn1(x):
+        raise my_exception
+
+    def fn2(x):
+        fn2_called.append(0)
+        raise AssertionError("Can't get here!")  # pragma: no cover
+
+    flat_map_executor = Executors.wrap(executor).\
+        with_flat_map(fn1).\
+        with_flat_map(fn2)
+
+    inputs = [1, 2]
+
+    futures = [flat_map_executor.submit(lambda v: v, x) for x in inputs]
+
+    # The innermost exception should have been raised (exactly)
+    assert_that(futures[0].exception() is my_exception)
+    assert_that(futures[1].exception() is my_exception)
+
+    # The outermost function should never have been called
+    assert_that(fn2_called, equal_to([]))


### PR DESCRIPTION
This is the typical flatmap concept as seen in e.g. scala's Future
objects. Allows chaining any number of Future-producing mapping
functions behind a single Future.