### PR TITLE
Refactor method chaining

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -217,7 +217,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=with_.*,bind
+generated-members=
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ def fetch_urls(urls):
 
 ### v1.14.0
 
+- API break: removed `Executors.wrap` class method
 - Fixed thread leaks when `shutdown()` is never called
   ([#87](https://github.com/rohanpm/more-executors/issues/87))
+- Refactors to avoid pylint errors from client code
+  ([#86](https://github.com/rohanpm/more-executors/issues/86))
 
 ### v1.13.0
 

--- a/more_executors/_bind.py
+++ b/more_executors/_bind.py
@@ -1,7 +1,9 @@
 from functools import update_wrapper
 
+from more_executors._wrap import CanCustomize
 
-class BoundCallable(object):
+
+class BoundCallable(CanCustomize, object):
     def __init__(self, executor, fn):
         self.__executor = executor
         self.__fn = fn

--- a/more_executors/_wrap.py
+++ b/more_executors/_wrap.py
@@ -1,0 +1,42 @@
+class CanBind(object):
+    def bind(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.bind(self, *args, **kwargs)
+
+
+class CanCustomize(object):
+    def with_retry(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_retry(self, *args, **kwargs)
+
+    def with_map(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_map(self, *args, **kwargs)
+
+    def with_flat_map(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_flat_map(self, *args, **kwargs)
+
+    def with_poll(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_poll(self, *args, **kwargs)
+
+    def with_timeout(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_timeout(self, *args, **kwargs)
+
+    def with_throttle(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_throttle(self, *args, **kwargs)
+
+    def with_cancel_on_shutdown(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_cancel_on_shutdown(self, *args, **kwargs)
+
+    def with_asyncio(self, *args, **kwargs):
+        from more_executors._executors import Executors
+        return Executors.with_asyncio(self, *args, **kwargs)
+
+
+class CanCustomizeBind(CanBind, CanCustomize):
+    pass

--- a/more_executors/_wrapped.py
+++ b/more_executors/_wrapped.py
@@ -1,0 +1,10 @@
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from more_executors._wrap import CanCustomizeBind
+
+
+class CustomizableThreadPoolExecutor(CanCustomizeBind, ThreadPoolExecutor):
+    pass
+
+
+class CustomizableProcessPoolExecutor(CanCustomizeBind, ProcessPoolExecutor):
+    pass

--- a/more_executors/cancel_on_shutdown.py
+++ b/more_executors/cancel_on_shutdown.py
@@ -3,12 +3,14 @@ from concurrent.futures import Executor
 from threading import RLock
 import logging
 
+from more_executors._wrap import CanCustomizeBind
+
 __pdoc__ = {}
 __pdoc__['CancelOnShutdownExecutor.submit'] = None
 __pdoc__['CancelOnShutdownExecutor.map'] = None
 
 
-class CancelOnShutdownExecutor(Executor):
+class CancelOnShutdownExecutor(CanCustomizeBind, Executor):
     """An `Executor` which delegates to another `Executor` and cancels all
     futures when the executor is shut down.
 

--- a/more_executors/map.py
+++ b/more_executors/map.py
@@ -3,6 +3,7 @@
 from concurrent.futures import Executor
 
 from more_executors._common import _Future
+from more_executors._wrap import CanCustomizeBind
 
 __pdoc__ = {}
 __pdoc__['MapExecutor.shutdown'] = None
@@ -69,7 +70,7 @@ class _MapFuture(_Future):
         return self._delegate.cancel()
 
 
-class MapExecutor(Executor):
+class MapExecutor(CanCustomizeBind, Executor):
     """An `Executor` which delegates to another `Executor` while mapping
     output values through a given function.
     """

--- a/more_executors/poll.py
+++ b/more_executors/poll.py
@@ -7,6 +7,7 @@ import sys
 import logging
 
 from more_executors._common import _Future, _MAX_TIMEOUT
+from more_executors._wrap import CanCustomizeBind
 
 __pdoc__ = {}
 __pdoc__['PollExecutor.shutdown'] = None
@@ -86,7 +87,7 @@ if sys.version_info[0] > 2:
         """The poll function can call this function to make the future raise the given exception."""
 
 
-class PollExecutor(Executor):
+class PollExecutor(CanCustomizeBind, Executor):
     """Instances of `PollExecutor` submit callables to a delegate `Executor`
     and resolve the returned futures via a provided poll function.
 

--- a/more_executors/retry.py
+++ b/more_executors/retry.py
@@ -13,6 +13,7 @@ import weakref
 from monotonic import monotonic
 
 from more_executors._common import _Future, _MAX_TIMEOUT
+from more_executors._wrap import CanCustomizeBind
 
 # Hide some docs which would otherwise be repeated
 __pdoc__ = {}
@@ -133,7 +134,7 @@ class _RetryFuture(_Future):
         return executor and executor._cancel(self)
 
 
-class RetryExecutor(Executor):
+class RetryExecutor(CanCustomizeBind, Executor):
     """An `Executor` which delegates to another `Executor` while adding
     implicit retry behavior.
 

--- a/more_executors/sync.py
+++ b/more_executors/sync.py
@@ -1,13 +1,14 @@
 """An executor which invokes callables synchronously."""
 from concurrent.futures import Executor, Future
 
+from more_executors._wrap import CanCustomizeBind
 
 __pdoc__ = {}
 __pdoc__['SyncExecutor.map'] = None
 __pdoc__['SyncExecutor.shutdown'] = None
 
 
-class SyncExecutor(Executor):
+class SyncExecutor(CanCustomizeBind, Executor):
     """An `Executor` which immediately invokes all submitted callables.
 
     This executor is useful for testing.  With executor implementations

--- a/more_executors/throttle.py
+++ b/more_executors/throttle.py
@@ -6,6 +6,7 @@ import logging
 import weakref
 
 from more_executors._common import _MAX_TIMEOUT
+from more_executors._wrap import CanCustomizeBind
 from more_executors.map import _MapFuture
 
 __pdoc__ = {}
@@ -29,7 +30,7 @@ class _ThrottleFuture(_MapFuture):
 _ThrottleJob = namedtuple('_ThrottleJob', ['future', 'fn', 'args', 'kwargs'])
 
 
-class ThrottleExecutor(Executor):
+class ThrottleExecutor(CanCustomizeBind, Executor):
     """An `Executor` which delegates to another `Executor` while enforcing
     a limit on the number of futures running concurrently.
 

--- a/more_executors/timeout.py
+++ b/more_executors/timeout.py
@@ -8,6 +8,7 @@ from monotonic import monotonic
 
 from more_executors.map import _MapFuture
 from more_executors._common import _MAX_TIMEOUT
+from more_executors._wrap import CanCustomizeBind
 
 __pdoc__ = {}
 __pdoc__['TimeoutExecutor.map'] = None
@@ -22,7 +23,7 @@ class _TimeoutFuture(_MapFuture):
         super(_TimeoutFuture, self).__init__(delegate, lambda x: x)
 
 
-class TimeoutExecutor(Executor):
+class TimeoutExecutor(CanCustomizeBind, Executor):
     """An `Executor` which delegates to another `Executor` while applying
     a timeout to each returned future.
 

--- a/tests/test_flat_map.py
+++ b/tests/test_flat_map.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from pytest import fixture
 from hamcrest import assert_that, equal_to, instance_of, calling, raises
 
@@ -8,7 +7,7 @@ from more_executors.flat_map import FlatMapExecutor
 
 @fixture
 def executor():
-    return ThreadPoolExecutor()
+    return Executors.thread_pool()
 
 
 def add1(x):
@@ -77,7 +76,7 @@ def test_flat_map_nofuture(executor):
 def test_chained_flat_map(executor):
     """Chaining multiple flatmaps pass through values as expected."""
 
-    flat_map_executor = Executors.wrap(executor).\
+    flat_map_executor = executor.\
         with_flat_map(lambda x: executor.submit(mult10, x)).\
         with_flat_map(lambda x: executor.submit(add1, x))
 
@@ -103,7 +102,7 @@ def test_chained_flat_map_exception(executor):
         fn2_called.append(0)
         raise AssertionError("Can't get here!")  # pragma: no cover
 
-    flat_map_executor = Executors.wrap(executor).\
+    flat_map_executor = executor.\
         with_flat_map(fn1).\
         with_flat_map(fn2)
 


### PR DESCRIPTION
Drop Executors.wrap method, which is too dynamic for tools such as
pylint to perform type inference. Replace it with a static API
provided by mixins.

Removal of the Executors.wrap method is is a backwards-incompatible
API change.

Fixes #86