### PR TITLE
Fix (another) thread leak in ThrottleExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ def fetch_urls(urls):
 
 ## Changelog
 
+### v1.15.0
+
+- Fixed ThrottleExecutor thread leak when `shutdown()` is never called
+  ([#93](https://github.com/rohanpm/more-executors/issues/93))
+
 ### v1.14.0
 
 - API break: removed `Executors.wrap` class method


### PR DESCRIPTION
The thread's main loop did "del executor" before waiting on the event,
but it could still hold a reference to the executor from 'to_submit'
or 'job'.

Fixes #93