### PR TITLE
push-docs: ensure circle config is copied to gh-pages

### DIFF
--- a/scripts/push-docs
+++ b/scripts/push-docs
@@ -9,6 +9,9 @@ fi
 
 rev=$(git rev-parse --short HEAD)
 
+# Copy circle config under docs build so that circle knows to ignore gh-pages branch
+cp -rv .circleci docs/_build
+
 cd docs/_build
 
 git init


### PR DESCRIPTION
Otherwise it'll always try to build the branch.