### PR TITLE
Get InvalidStateError from asyncio directly

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -27,7 +27,7 @@ def test_run(asyncio):
         f = executor.submit(sleep_then_return, 0.01, 'abc')
 
         # The result should not be available yet
-        assert_that(calling(f.result), raises(asyncio.futures.InvalidStateError))
+        assert_that(calling(f.result), raises(asyncio.InvalidStateError))
 
         # Running in event loop should work
         result = asyncio.get_event_loop().run_until_complete(f)


### PR DESCRIPTION
Apparently, this exception is available from asyncio, not asyncio.futures (that was merely a leaking import):

    $ python3.7 -c 'import asyncio; asyncio.futures.InvalidStateError'
    $ python3.8 -c 'import asyncio; asyncio.futures.InvalidStateError'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    AttributeError: module 'asyncio.futures' has no attribute 'InvalidStateError'

    $ python3.8 -c 'import asyncio; asyncio.InvalidStateError'
    $ python3.7 -c 'import asyncio; asyncio.InvalidStateError'
    $ python3.6 -c 'import asyncio; asyncio.InvalidStateError'
    $ python3.5 -c 'import asyncio; asyncio.InvalidStateError'
    $ python3.4 -c 'import asyncio; asyncio.InvalidStateError'

See also https://bugzilla.redhat.com/show_bug.cgi?id=1705459