### PR TITLE
CI: fix testing for externally submitted PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,12 @@ workflows:
         context: secrets
         post-steps:
         - run: scripts/push-docs
-        filters:
-          <<: *ci_filters
+        filters: &post_merge_filters
+          branches:
+            only:
+            - master
+          tags:
+            only: /^v.*/
     - python/codeclimate-upload-coverage:
         name: Submit coverage results to codeclimate
         test_reporter_id: d02a1b5b6e33a7225c7c9e39145d3e89dc984a56e465bac4f9d276bba6ee4b84
@@ -76,4 +80,4 @@ workflows:
         - Static checks
         - Build docs
         filters:
-          <<: *ci_filters
+          <<: *post_merge_filters


### PR DESCRIPTION
I had expected that environment variables in a given `context`
are simply omitted for runs triggered by an unauthorized user,
but instead the build simply fails.  To fix this, move the
configurations which need a context into post-merge trigger only.

The downside is that docs building is no longer tested prior to merge.