### PR TITLE
Add default value of None to f_return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+- It is now possible to call `f_return` with no arguments. This produces a future
+  with a return value of `None`.
 
 ## [2.0.2] - 2019-05-03
 

--- a/more_executors/_impl/futures/base.py
+++ b/more_executors/_impl/futures/base.py
@@ -6,7 +6,7 @@ from ..executors import Executors
 from ..common import copy_exception
 
 
-def f_return(x):
+def f_return(x=None):
     """Return a future which provides the value `x`.
 
     Signature: :code:`A ⟶ Future<A>`
@@ -20,6 +20,8 @@ def f_return(x):
             A future immediately resolved with the value :obj:`x`.
 
     .. versionadded:: 1.19.0
+    .. versionchanged:: 2.1.0
+        value now defaults to :code:`None`
     """
     return Executors.sync().submit(lambda: x)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_install_requires():
 
 setup(
     name='more-executors',
-    version='2.0.2',
+    version='2.1.0',
     author='Rohan McGovern',
     author_email='rohan@mcgovern.id.au',
     packages=find_packages(exclude=['tests', 'tests.*']),

--- a/tests/futures/test_return.py
+++ b/tests/futures/test_return.py
@@ -6,6 +6,10 @@ def test_f_return():
     assert f_return(value).result() is value
 
 
+def test_f_return_no_value():
+    assert f_return().result() is None
+
+
 def test_f_return_error():
     exception = RuntimeError('simulated error')
     assert f_return_error(exception).exception() is exception


### PR DESCRIPTION
f_return() now produces a future which produces None. This makes
sense for cases where a future is used to represent completion of
some task, but no further information is available from the task
beyond either "completed successfully" or "raised an exception".