### PR TITLE
Type check inputs to functions in more_executors.futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+- Most functions in `more_executors.futures` will now immediately raise a
+ `TypeError` if invoked with a non-future value where a future is expected.
+ ([#146](https://github.com/rohanpm/more-executors/issues/146))
 
 ## [2.1.0] - 2019-06-05
 

--- a/more_executors/_impl/futures/apply.py
+++ b/more_executors/_impl/futures/apply.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .base import wrap
+from .check import ensure_futures
 
 
 # for wrapping arguments.
@@ -8,6 +9,7 @@ from .base import wrap
 ARGS = object()
 
 
+@ensure_futures
 def f_apply(future_fn, *future_args, **future_kwargs):
     """Call a function, where the function, its arguments and return value
     are all provided by futures.

--- a/more_executors/_impl/futures/bool.py
+++ b/more_executors/_impl/futures/bool.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future
 
 from .base import chain_cancel
 from ..common import copy_future_exception
+from .check import ensure_futures
 
 
 LOG = logging.getLogger("more_executors.futures")
@@ -142,6 +143,7 @@ class AndCallback(BoolCallback):
         return (set_result, set_exception, cancel_future)
 
 
+@ensure_futures
 def f_or(f, *fs):
     """Boolean ``OR`` over a number of futures.
 
@@ -179,6 +181,7 @@ def f_or(f, *fs):
     return out
 
 
+@ensure_futures
 def f_and(f, *fs):
     """Boolean ``AND`` over a number of futures.
 

--- a/more_executors/_impl/futures/check.py
+++ b/more_executors/_impl/futures/check.py
@@ -1,0 +1,41 @@
+from functools import wraps
+
+
+def ensure_futures(f):
+    @wraps(f)
+    def new_fn(*args, **kwargs):
+        to_check = list(args)
+        to_check.extend(kwargs.values())
+
+        for arg in to_check:
+            if not is_future(arg):
+                raise TypeError(
+                    "%s() called with non-future value: %s" % (f.__name__, repr(arg))
+                )
+
+        return f(*args, **kwargs)
+
+    return new_fn
+
+
+def ensure_future(f):
+    @wraps(f)
+    def new_fn(*args, **kwargs):
+        arg = None
+        if args:
+            arg = args[0]
+        else:
+            arg = kwargs.get("future")
+
+        if not is_future(arg):
+            raise TypeError(
+                "%s() called with non-future value: %s" % (f.__name__, repr(arg))
+            )
+
+        return f(*args, **kwargs)
+
+    return new_fn
+
+
+def is_future(f):
+    return "add_done_callback" in dir(f)

--- a/more_executors/_impl/futures/map.py
+++ b/more_executors/_impl/futures/map.py
@@ -2,8 +2,10 @@
 
 from .base import wrap, f_return
 from .apply import f_apply
+from .check import ensure_future
 
 
+@ensure_future
 def f_map(future, fn):
     """Map the output value of a future using the given function.
 
@@ -26,6 +28,7 @@ def f_map(future, fn):
     return f_apply(future_fn, future)
 
 
+@ensure_future
 def f_flat_map(future, fn):
     """Map the output value of a future using the given future-returning function.
 

--- a/more_executors/_impl/futures/nocancel.py
+++ b/more_executors/_impl/futures/nocancel.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ..map import MapFuture
+from .check import ensure_future
 
 
 class NoCancelFuture(MapFuture):
@@ -8,6 +9,7 @@ class NoCancelFuture(MapFuture):
         return False
 
 
+@ensure_future
 def f_nocancel(future):
     """Wrap a future to block cancellation.
 

--- a/more_executors/_impl/futures/timeout.py
+++ b/more_executors/_impl/futures/timeout.py
@@ -5,11 +5,13 @@ from threading import Lock
 
 from more_executors import Executors
 
+from .check import ensure_future
 
 LOCK = Lock()
 EXECUTOR_REF = None
 
 
+@ensure_future
 def f_timeout(future, timeout):
     """Wrap a future to cancel it after a timeout is reached.
 

--- a/more_executors/_impl/futures/zip.py
+++ b/more_executors/_impl/futures/zip.py
@@ -2,8 +2,10 @@
 
 from .base import f_return, chain_cancel
 from .map import f_map, f_flat_map
+from .check import ensure_futures
 
 
+@ensure_futures
 def f_zip(*fs):
     """Create a new future holding the return values of any number of input futures.
 

--- a/tests/futures/test_checks.py
+++ b/tests/futures/test_checks.py
@@ -1,0 +1,62 @@
+import pytest
+
+
+from more_executors.futures import (
+    f_or,
+    f_and,
+    f_map,
+    f_flat_map,
+    f_zip,
+    f_apply,
+    f_nocancel,
+    f_timeout,
+)
+
+
+def test_or_error():
+    with pytest.raises(TypeError):
+        f_or("a", "b")
+
+
+def test_and_error():
+    with pytest.raises(TypeError):
+        f_and("a", "b")
+
+
+def test_map_error():
+    with pytest.raises(TypeError):
+        f_map("a", lambda x: x)
+
+    with pytest.raises(TypeError):
+        f_map(future="a", fn=lambda x: x)
+
+
+def test_flat_map_error():
+    with pytest.raises(TypeError):
+        f_flat_map("a", lambda x: x)
+
+    with pytest.raises(TypeError):
+        f_flat_map(future="a", fn=lambda x: x)
+
+
+def test_zip_error():
+    with pytest.raises(TypeError):
+        f_zip("a", "b", "c")
+
+
+def test_apply_error():
+    with pytest.raises(TypeError):
+        f_apply("a", "b", "c")
+
+
+def test_nocancel():
+    with pytest.raises(TypeError):
+        f_nocancel("a")
+
+    with pytest.raises(TypeError):
+        f_nocancel(future="a")
+
+
+def test_timeout():
+    with pytest.raises(TypeError):
+        f_timeout("a", 123.0)


### PR DESCRIPTION
Without this, if the caller accidentally passes a non-future value
where a future is expected, confusing errors could occur.

Closes #146