### PR TITLE
Introduce error_fn for map/flatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Added
+- map/flat_map now accept an `error_fn` to transform the result of an
+  unsuccessful future ([#153](https://github.com/rohanpm/more-executors/issues/153)).
 
 ## [2.1.2] - 2019-06-26
 

--- a/docs/reference/futures-map.rst
+++ b/docs/reference/futures-map.rst
@@ -16,9 +16,9 @@ Executors API
 .. autoclass:: more_executors.map.MapExecutor
    :members: submit
 
-.. automethod:: more_executors.Executors.with_map(executor, fn, logger=None)
+.. automethod:: more_executors.Executors.with_map(executor, fn=None, error_fn=None, logger=None)
 
 
 .. autoclass:: more_executors.flat_map.FlatMapExecutor
 
-.. automethod:: more_executors.Executors.with_flat_map(executor, fn, logger=None)
+.. automethod:: more_executors.Executors.with_flat_map(executor, fn=None, error_fn=None, logger=None)

--- a/more_executors/_impl/asyncio.py
+++ b/more_executors/_impl/asyncio.py
@@ -30,8 +30,8 @@ class AsyncioExecutor(Executor):
         self._delegate = delegate
         self._loop = loop
 
-    def submit(self, fn, *args, **kwargs):
-        return self.submit_with_loop(self._loop, fn, *args, **kwargs)
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        return self.submit_with_loop(self._loop, *args, **kwargs)
 
     def submit_with_loop(self, loop, fn, *args, **kwargs):
         """Submit a callable with the specified event loop.

--- a/more_executors/_impl/cancel_on_shutdown.py
+++ b/more_executors/_impl/cancel_on_shutdown.py
@@ -50,11 +50,11 @@ class CancelOnShutdownExecutor(CanCustomizeBind, Executor):
 
         self._delegate.shutdown(wait)
 
-    def submit(self, fn, *args, **kwargs):
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
         with self._lock:
             if self._shutdown:
                 raise RuntimeError("Cannot submit after shutdown")
-            future = self._delegate.submit(fn, *args, **kwargs)
+            future = self._delegate.submit(*args, **kwargs)
             self._futures.add(future)
             future.add_done_callback(self._futures.discard)
         return future

--- a/more_executors/_impl/futures/map.py
+++ b/more_executors/_impl/futures/map.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from .base import wrap, f_return
-from .apply import f_apply
+from .base import wrap
 from .check import ensure_future
 
 
 @ensure_future
-def f_map(future, fn):
-    """Map the output value of a future using the given function.
+def f_map(future, fn=None, error_fn=None):
+    """Map the output value of a future using the given functions.
 
     Signature: :code:`Future<A>, fn<A⟶B> ⟶ Future<B>`
 
@@ -15,24 +14,33 @@ def f_map(future, fn):
         future (~concurrent.futures.Future)
             Any future.
         fn (callable)
-            Any callable.
+            Any callable to be applied on successful futures.
+            This function is provided the result of the input future.
+        error_fn (callable)
+            Any callable to be applied on unsuccessful futures.
+            This function is provided the exception of the input future.
 
     Returns:
         :class:`~concurrent.futures.Future`
-            A future resolved with the returned value of :code:`fn(future.result())`,
-            or with the exception raised by :obj:`future` or :obj:`fn`.
+            A future resolved with:
+
+            - the returned value of :code:`fn(future.result())`
+            - or the returned value of :code:`error_fn(future.exception())`
+            - or with the exception raised by :obj:`future`, :obj:`fn` or :obj:`error_fn`.
 
     .. versionadded:: 1.19.0
+
+    .. versionchanged:: 2.2.0
+       Introduced ``error_fn``.
     """
-    future_fn = f_return(fn)
-    return f_apply(future_fn, future)
+    return wrap(future).with_map(fn=fn, error_fn=error_fn)()
 
 
 @ensure_future
-def f_flat_map(future, fn):
-    """Map the output value of a future using the given future-returning function.
+def f_flat_map(future, fn=None, error_fn=None):
+    """Map the output value of a future using the given future-returning functions.
 
-    Like :meth:`f_map`, except that the mapping function must return a future,
+    Like :meth:`f_map`, except that the mapping functions must return a future,
     and that future will be flattened into the output value (avoiding a nested future).
 
     Signature: :code:`Future<A>, fn<A⟶Future<B>> ⟶ Future<B>`
@@ -41,13 +49,24 @@ def f_flat_map(future, fn):
         future (~concurrent.futures.Future)
             Any future.
         fn (callable)
-            Any callable which returns a future.
+            Any future-returning callable to be applied on successful futures.
+            This function is provided the result of the input future.
+        error_fn (callable)
+            Any future-returning callable to be applied on unsuccessful futures.
+            This function is provided the exception of the input future.
 
     Returns:
         :class:`~concurrent.futures.Future`
-            A future equivalent to that returned by :obj:`fn`, or resolved with an exception
-            if :obj:`future` or :obj:`fn` failed.
+            A future which is:
+
+            - equivalent to that returned by :obj:`fn` if input future succeeded
+            - or equivalent to that returned by :obj:`error_fn` if input future failed
+            - or resolved with an exception if any of :obj:`future`, :obj:`fn` or
+              :obj:`error_fn` failed
 
     .. versionadded:: 1.19.0
+
+    .. versionchanged:: 2.2.0
+       Introduced ``error_fn``.
     """
-    return wrap(future).with_flat_map(fn)()
+    return wrap(future).with_flat_map(fn=fn, error_fn=error_fn)()

--- a/more_executors/_impl/map.py
+++ b/more_executors/_impl/map.py
@@ -136,6 +136,6 @@ class MapExecutor(CanCustomizeBind, Executor):
     def shutdown(self, wait=True):
         self._delegate.shutdown(wait)
 
-    def submit(self, fn, *args, **kwargs):
-        inner_f = self._delegate.submit(fn, *args, **kwargs)
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        inner_f = self._delegate.submit(*args, **kwargs)
         return self._FUTURE_CLASS(inner_f, self._fn, self._error_fn)

--- a/more_executors/_impl/poll.py
+++ b/more_executors/_impl/poll.py
@@ -169,8 +169,8 @@ class PollExecutor(CanCustomizeBind, Executor):
 
         self._poll_thread.start()
 
-    def submit(self, fn, *args, **kwargs):
-        delegate_future = self._delegate.submit(fn, *args, **kwargs)
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        delegate_future = self._delegate.submit(*args, **kwargs)
         return PollFuture(delegate_future, self)
 
     def _register_poll(self, future, delegate_future):

--- a/more_executors/_impl/retry.py
+++ b/more_executors/_impl/retry.py
@@ -229,8 +229,8 @@ class RetryExecutor(CanCustomizeBind, Executor):
             self._submit_thread.join(MAX_TIMEOUT)
         self._log.debug("Shutdown complete")
 
-    def submit(self, fn, *args, **kwargs):
-        return self.submit_retry(self._default_retry_policy, fn, *args, **kwargs)
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        return self.submit_retry(self._default_retry_policy, *args, **kwargs)
 
     def submit_retry(self, retry_policy, fn, *args, **kwargs):
         """Submit a callable with a specific retry policy.

--- a/more_executors/_impl/sync.py
+++ b/more_executors/_impl/sync.py
@@ -15,7 +15,7 @@ class SyncExecutor(CanCustomizeBind, Executor):
         """
         super(SyncExecutor, self).__init__()
 
-    def submit(self, fn, *args, **kwargs):
+    def submit(self, fn, *args, **kwargs):  # pylint: disable=arguments-differ
         """Immediately invokes `fn(*args, **kwargs)` and returns a future
         with the result (or exception)."""
         future = Future()

--- a/more_executors/_impl/throttle.py
+++ b/more_executors/_impl/throttle.py
@@ -76,7 +76,7 @@ class ThrottleExecutor(CanCustomizeBind, Executor):
         self._thread.daemon = True
         self._thread.start()
 
-    def submit(self, fn, *args, **kwargs):
+    def submit(self, fn, *args, **kwargs):  # pylint: disable=arguments-differ
         out = ThrottleFuture(self)
         job = ThrottleJob(out, fn, args, kwargs)
         with self._lock:

--- a/more_executors/_impl/timeout.py
+++ b/more_executors/_impl/timeout.py
@@ -61,8 +61,8 @@ class TimeoutExecutor(CanCustomizeBind, Executor):
         self._job_thread.daemon = True
         self._job_thread.start()
 
-    def submit(self, fn, *args, **kwargs):
-        return self.submit_timeout(self._timeout, fn, *args, **kwargs)
+    def submit(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        return self.submit_timeout(self._timeout, *args, **kwargs)
 
     def submit_timeout(self, timeout, fn, *args, **kwargs):
         """Like :code:`submit(fn, *args, **kwargs)`, but uses the specified

--- a/more_executors/_impl/timeout.py
+++ b/more_executors/_impl/timeout.py
@@ -16,11 +16,6 @@ LOG = logging.getLogger("TimeoutExecutor")
 Job = namedtuple("Job", ["future", "delegate_future", "deadline"])
 
 
-class TimeoutFuture(MapFuture):
-    def __init__(self, delegate):
-        super(TimeoutFuture, self).__init__(delegate, lambda x: x)
-
-
 class TimeoutExecutor(CanCustomizeBind, Executor):
     """An executor which delegates to another executor while applying
     a timeout to each returned future.
@@ -76,7 +71,7 @@ class TimeoutExecutor(CanCustomizeBind, Executor):
         .. versionadded:: 1.19.0
         """
         delegate_future = self._delegate.submit(fn, *args, **kwargs)
-        future = TimeoutFuture(delegate_future)
+        future = MapFuture(delegate_future)
         future.add_done_callback(self._on_future_done)
         job = Job(future, delegate_future, monotonic() + timeout)
         with self._jobs_lock:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_install_requires():
 
 setup(
     name="more-executors",
-    version="2.1.2",
+    version="2.2.0",
     author="Rohan McGovern",
     author_email="rohan@mcgovern.id.au",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/futures/test_flat_map.py
+++ b/tests/futures/test_flat_map.py
@@ -1,0 +1,51 @@
+from more_executors.futures import f_flat_map, f_return, f_return_error
+
+
+def div10(x):
+    try:
+        return f_return(10 / x)
+    except Exception as ex:
+        return f_return_error(ex)
+
+
+def raise_str(x):
+    raise RuntimeError("oops, an error: %s" % x)
+
+
+def test_flat_map_nothing():
+    map_in = f_return(10)
+    mapped = f_flat_map(map_in)
+    assert mapped.result() == 10
+
+
+def test_flat_map():
+    map_in = f_return(10)
+    mapped = f_flat_map(map_in, div10)
+    assert mapped.result() == 1
+
+
+def test_flat_map_error():
+    map_in = f_return(0)
+
+    # This one should fail...
+    mapped = f_flat_map(map_in, div10)
+
+    # Now map it through an error handler
+    mapped = f_flat_map(mapped, error_fn=lambda ex: f_return(str(ex)))
+
+    result = mapped.result()
+    assert "division" in result
+
+
+def test_flat_map_error_fn_raises():
+    map_in = f_return(0)
+
+    # This one should fail...
+    mapped = f_flat_map(map_in, div10)
+
+    # Now map it through an error handler
+    mapped = f_flat_map(mapped, error_fn=raise_str)
+
+    ex = mapped.exception()
+    assert "division" in str(ex)
+    assert "oops, an error" in str(ex)

--- a/tests/futures/test_map.py
+++ b/tests/futures/test_map.py
@@ -1,0 +1,30 @@
+from more_executors.futures import f_map, f_return
+
+
+def div10(x):
+    return 10 / x
+
+
+def test_map_nothing():
+    map_in = f_return(10)
+    mapped = f_map(map_in)
+    assert mapped.result() == 10
+
+
+def test_map():
+    map_in = f_return(10)
+    mapped = f_map(map_in, div10)
+    assert mapped.result() == 1
+
+
+def test_map_error():
+    map_in = f_return(0)
+
+    # This one should fail...
+    mapped = f_map(map_in, div10)
+
+    # Now map it through an error handler
+    mapped = f_map(mapped, error_fn=str)
+
+    result = mapped.result()
+    assert "division" in result


### PR DESCRIPTION
Sometimes we want to catch certain types of errors and transform
them into a successful result.  Add the needed feature to
map/flatmap to support this use-case.