### PR TITLE
CI: add reverse dependency tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,18 @@ workflows:
         filters:
           <<: *ci_filters
     - python/tox:
+        name: "Reverse dependency tests: pubtools-pulplib"
+        toxenv: revdep-pulplib
+        executor: python/python37
+        filters:
+          <<: *ci_filters
+    - python/tox:
+        name: "Reverse dependency tests: python-fastpurge"
+        toxenv: revdep-fastpurge
+        executor: python/python37
+        filters:
+          <<: *ci_filters
+    - python/tox:
         name: API compatibility check
         toxenv: pidiff
         filters:
@@ -77,6 +89,8 @@ workflows:
         - Python 2.7 tests
         - Python 3.6 tests
         - Python 3.7 tests
+        - "Reverse dependency tests: python-fastpurge"
+        - "Reverse dependency tests: pubtools-pulplib"
         - Static checks
         - Build docs
         filters:

--- a/scripts/revdep-test
+++ b/scripts/revdep-test
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Reverse dependency tester.
+#
+# This script is intended to be run within a virtualenv with latest
+# version of more-executors installed. It'll run autotests from
+# some *other* project which depends on more-executors.
+URL="$1"
+
+CLONE_DIR=$(mktemp -d -t --suffix=revdep)
+
+clean(){
+  rm -rf $CLONE_DIR
+}
+trap clean EXIT
+
+set -xe
+
+git clone "$URL" "$CLONE_DIR"
+cd "$CLONE_DIR"
+
+pip install --editable .
+if test -e test-requirements.txt; then
+  pip install -rtest-requirements.txt
+fi
+
+py.test -v

--- a/tox.ini
+++ b/tox.ini
@@ -52,5 +52,23 @@ deps=
 commands=
 	pidiff more-executors .
 
+[testenv:revdep-pulplib]
+whitelist_externals=sh
+use_develop=true
+commands=
+	sh -c 'scripts/revdep-test https://github.com/release-engineering/pubtools-pulplib.git'
+
+[testenv:revdep-fastpurge]
+whitelist_externals=sh
+use_develop=true
+commands=
+	sh -c 'scripts/revdep-test https://github.com/release-engineering/python-fastpurge.git'
+
+[testenv:revdep-ubipop]
+whitelist_externals=sh
+use_develop=true
+commands=
+	sh -c 'scripts/revdep-test https://github.com/release-engineering/ubi-population-tool.git'
+
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
To give more confidence that changes don't introduce regressions
or incompatibilities, let's run the tests of some *other* projects
which depend on us.

This is a bit of an experiment and I'm not sure how well it will
work in practice.  It depends on the other projects keeping their
tests entirely stable, and it might run through the CircleCI
quota pretty quick.