### PR TITLE
Introduce PollExecutor.notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ from version 1.20.0 onwards.
 ### Added
 - map/flat_map now accept an `error_fn` to transform the result of an
   unsuccessful future ([#153](https://github.com/rohanpm/more-executors/issues/153)).
+- Introduced `PollExecutor.notify` to wake up a `PollExecutor` early
+  ([#152](https://github.com/rohanpm/more-executors/issues/152)).
 
 ## [2.1.2] - 2019-06-26
 

--- a/more_executors/_impl/poll.py
+++ b/more_executors/_impl/poll.py
@@ -173,6 +173,19 @@ class PollExecutor(CanCustomizeBind, Executor):
         delegate_future = self._delegate.submit(*args, **kwargs)
         return PollFuture(delegate_future, self)
 
+    def notify(self):
+        """Request the executor to re-run the polling function as soon as possible.
+
+        This method may be used to perform the next poll earlier than it would
+        otherwise run.
+
+        This is useful for cases where futures may be resolved via a mixture of
+        polling and external events.
+
+        .. versionadded:: 2.2.0
+        """
+        self._poll_event.set()
+
     def _register_poll(self, future, delegate_future):
         descriptor = PollDescriptor(future, delegate_future.result())
         with self._lock:


### PR DESCRIPTION
This method allows waking up a PollExecutor early; useful if
some external event gives us a hint that polling now is likely to
be helpful.

Fixes #152