### PR TITLE
Improve performance/limits of various functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fixed some scaling/performance issues with functions dealing with collections
+  of futures (`f_or`, `f_and`, `f_sequence`, `f_zip`). These functions now support
+  up to 100,000 input futures. In earlier versions of the library, these would
+  break with approximately ~1,000 inputs.
 
 ## [2.3.0] - 2019-09-07
 

--- a/more_executors/_impl/futures/sequence.py
+++ b/more_executors/_impl/futures/sequence.py
@@ -24,6 +24,10 @@ def f_sequence(futures):
             - a list holding the output value of each input future
             - or an exception, if any input future raised an exception
 
+    .. note::
+        This function is tested with up to 100,000 input futures.
+        Exceeding this limit may result in performance issues.
+
     .. versionadded:: 1.19.0
     """
     return f_traverse(lambda x: x, futures)

--- a/tests/futures/test_and.py
+++ b/tests/futures/test_and.py
@@ -2,7 +2,7 @@ import time
 import pytest
 
 from more_executors import Executors
-from more_executors.futures import f_and, f_nocancel
+from more_executors.futures import f_return, f_and, f_nocancel
 from .bool_utils import (
     falsey,
     truthy,
@@ -163,3 +163,9 @@ def test_and_propagate_traceback():
     ]
     future = f_and(*futures)
     assert_in_traceback(future, "inner_test_fn")
+
+
+def test_and_large():
+    inputs = [f_return(True) for _ in range(0, 100000)]
+
+    assert f_and(*inputs).result() is True

--- a/tests/futures/test_traverse.py
+++ b/tests/futures/test_traverse.py
@@ -20,6 +20,12 @@ def test_sequence_error():
     assert f.exception() is error
 
 
+def test_sequence_large():
+    limit = 100000
+    f = f_sequence([f_return(i) for i in range(0, limit)])
+    assert f.result() == list(range(0, limit))
+
+
 def test_traverse():
     future = f_traverse(div100by_async, [10, 25, 50])
     assert future.result() == [10, 4, 2]

--- a/tests/futures/test_zip.py
+++ b/tests/futures/test_zip.py
@@ -1,4 +1,6 @@
-from more_executors.futures import f_zip, f_return
+from concurrent.futures import Future
+
+from more_executors.futures import f_zip, f_return, f_return_error
 
 
 def test_zip_single():
@@ -18,3 +20,32 @@ def test_zip_three():
     f_c = f_return("c")
     future = f_zip(f_a, f_b, f_c)
     assert future.result() == ("a", "b", "c")
+
+
+def test_zip_error():
+    error = RuntimeError("simulated error")
+    f_a = f_return("a")
+    f_b = f_return_error(error)
+    f_c = f_return("c")
+    future = f_zip(f_a, f_b, f_c)
+    assert future.exception() is error
+
+
+def test_zip_cancel():
+    f_a = f_return("a")
+    f_b = Future()
+    f_c = Future()
+    future = f_zip(f_a, f_b, f_c)
+
+    future.cancel()
+
+    assert f_b.cancelled()
+    assert f_c.cancelled()
+
+
+def test_zip_large():
+    fs = [f_return(i) for i in range(0, 100000)]
+    future = f_zip(*fs)
+    result = future.result()
+    assert result[0:5] == (0, 1, 2, 3, 4)
+    assert len(result) == 100000


### PR DESCRIPTION
These functions operate on collections of futures:

- f_sequence
- f_zip
- f_and
- f_or

The previous implementations of these relied on recursion. This
meant the functions would consume O(N) stack frames where N is
the number of futures provided as input. In practice, this caused
all of the functions to stop working at around ~1,000 inputs.

That's not enough for some important use-cases, so let's rewrite
them to avoid recursion and raise the limits considerably. The new
implementations are verified as working with 100,000 inputs, and
this limit has been documented.