### PR TITLE
Avoid AttributeError wrongly appearing in exception cause chain

### DIFF
--- a/more_executors/_impl/common.py
+++ b/more_executors/_impl/common.py
@@ -92,5 +92,8 @@ def copy_exception(future, exception=None, traceback=None):
 
     try:
         future.set_exception_info(exception, traceback)
+        return
     except AttributeError:
-        future.set_exception(exception)
+        pass
+
+    future.set_exception(exception)


### PR DESCRIPTION
We have an AttributeError fallback here to support py2 vs py3
differences, but that error can end up appearing in tracebacks
for library users when it shouldn't. Rearrange the code slightly
to avoid that.

Fixes #162