### PR TITLE
map: don't apply any default error_fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+- Internal refactoring to simplify backtraces in certain cases
+  ([#169](https://github.com/rohanpm/more-executors/issues/169)).
 
 ## [2.4.0] - 2019-09-15
 


### PR DESCRIPTION
Letting error_fn default to a function which re-raises the exception
simplified the code, but unfortunately those re-raises end up in the
backtraces seen by user code, and will add one stack frame per
map. This is ugly and possibly misleads users into thinking something
is going wrong, so let's not do it that way.

Fixes #169