### PR TITLE
Drop flake8 from static checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -144,6 +144,10 @@ disable=
     bad-continuation,
     # Nothing wrong with a small number of public methods
     too-few-public-methods,
+    # Python 3.9 is changing the signature of Executor.shutdown().
+    # Not sure how to deal with it yet, but it likely will trigger
+    # this warning.
+    signature-differs,
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/tox.ini
+++ b/tox.ini
@@ -22,15 +22,9 @@ basepython=python2.7
 
 [testenv:static]
 deps=
-	flake8
-	mccabe
-	flake8-bugbear
 	pylint
 	-rtest-requirements.txt
 commands=
-	flake8 \
-	  --max-complexity 10 \
-          more_executors tests
 	sh -c 'pylint more_executors tests; test $(( $? & (1|2|4|32) )) = 0'
 
 [testenv:docs]


### PR DESCRIPTION
We use black in pre-commit hook now. It sometimes conflicts with
flake8.