### PR TITLE
Fix a possible hang on Python exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fixed a potential hang on exit when executors are not explicitly shut down
+ ([#176](https://github.com/rohanpm/more-executors/issues/176))
 
 ## [2.5.0] - 2019-09-23
 

--- a/more_executors/_impl/event.py
+++ b/more_executors/_impl/event.py
@@ -1,0 +1,50 @@
+"""Helper to get shutdown-aware instances of Event.
+
+Call get_event to get instances of threading.Event.
+
+These events work like any other event except that they will be automatically
+set() during interpreter exit.  If an event has been set() for this reason,
+is_shutdown() will return True.
+"""
+
+from threading import Event, RLock
+import weakref
+import atexit
+
+
+class ShutdownAwareEventHandler(object):
+    def __init__(self):
+        self.lock = RLock()
+        self.atexit_registered = False
+        self.shutdown = False
+        # NOTE: no weakset until python <2.7 is dropped
+        self.events = []
+
+    def clean_events(self, *_args, **_kwargs):
+        with self.lock:
+            self.events = [evt_ref for evt_ref in self.events if evt_ref()]
+
+    def on_exiting(self):
+        self.shutdown = True
+
+        for evt_ref in self.events:
+            evt = evt_ref()
+            if evt:
+                evt.set()
+
+    def get_event(self):
+        with self.lock:
+            if not self.atexit_registered:
+                atexit.register(self.on_exiting)
+                self.atexit_registered = True
+            out = Event()
+            self.events.append(weakref.ref(out, self.clean_events))
+            return out
+
+
+GLOBAL_HANDLER = ShutdownAwareEventHandler()
+get_event = GLOBAL_HANDLER.get_event
+
+
+def is_shutdown():
+    return GLOBAL_HANDLER.shutdown


### PR DESCRIPTION
For executors using threads, the threads would automatically exit
themselves once their creating executors were garbage collected,
so calling shutdown() is not generally required. However, it seems
possible that an atexit function could block on joining one of
these threads *prior to* GC of the executor, leading to a deadlock.
Let's also make the threads bail out at interpreter exit via atexit
to be defensive against this scenario.

Fixes #176