### PR TITLE
tests: fix unconditional dependency on mock

### DIFF
--- a/tests/retry/test_retry.py
+++ b/tests/retry/test_retry.py
@@ -16,7 +16,10 @@ from hamcrest import (
 )
 from pytest import fixture
 
-from mock import MagicMock, call
+try:
+    from unittest.mock import MagicMock, call
+except ImportError:
+    from mock import MagicMock, call
 
 from more_executors.retry import RetryExecutor, ExceptionRetryPolicy, RetryPolicy
 


### PR DESCRIPTION
This had previously used unittest.mock on py3 and mock on py2.
Between v2.5.1 and v2.6.0 it was changed to always use mock,
for unclear reasons. Revert that.