### PR TITLE
Adjust internal executor usage for better metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ from version 1.20.0 onwards.
   Type information is not complete, but is sufficient for most typical
   scenarios for composing executors and futures. Requires Python 3.9 or later.
 
+## Changed
+- Internal refactoring to improve usability of prometheus metrics.
+
 ## [2.7.0] - 2021-07-11
 
 ### Added

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -346,3 +346,5 @@ Metrics include the following labels:
     ``executor``
         Name of executor (see :ref:`Naming executors`).
 
+        Executors created for internal use by this library are named
+        ``internal``.

--- a/more_executors/_impl/flat_map.py
+++ b/more_executors/_impl/flat_map.py
@@ -1,13 +1,11 @@
 from .map import MapFuture, MapExecutor
-from .sync import SyncExecutor
-
-
-def f_return(x):
-    return SyncExecutor().submit(lambda: x)
 
 
 class FlatMapFuture(MapFuture):
     def __init__(self, delegate, map_fn=None, error_fn=None):
+        # avoiding circular dep
+        from ..futures import f_return
+
         self.__flattened = False
         map_fn = map_fn or f_return
         super(FlatMapFuture, self).__init__(delegate, map_fn, error_fn)

--- a/more_executors/_impl/futures/timeout.py
+++ b/more_executors/_impl/futures/timeout.py
@@ -41,6 +41,12 @@ def timeout_executor():
     with LOCK:
         executor = EXECUTOR_REF and EXECUTOR_REF()
         if not executor:
-            executor = Executors.sync().with_flat_map(lambda x: x).with_timeout(None)
+            # TODO: consider rethinking this and keeping one
+            # executor alive until atexit() instead.
+            executor = (
+                Executors.sync(name="internal")
+                .with_flat_map(lambda x: x)
+                .with_timeout(None)
+            )
             EXECUTOR_REF = weakref.ref(executor)
         return executor


### PR DESCRIPTION
Previously, Executors.sync() was freely used internally as a simple
way of code reuse. That works fine since a SyncExecutor has a trivial
implementation.

However, it throws off the new prometheus metrics, as every one of
those will increment the executor totals, and also inprogress as we
usually don't bother shutting them down.

Improve that by:

- most notably, dropping Executors.sync() in f_return
- reusing a singleton executor in some other cases
- putting "internal" name on some remaining executors so they can
  be identified in the metrics

Fixes #273.