### PR TITLE
Improve consistency of shutdown behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ from version 1.20.0 onwards.
 
 ## Changed
 - Internal refactoring to improve usability of prometheus metrics.
+- Improved consistency of shutdown behavior. Previously, the behavior on
+  incorrect usage of executors such as submit-after-shutdown or multiple calls
+  to shutdown was not strictly defined and could differ between executors.
+  Every executor will now raise an exception on submit-after-shutdown and
+  will tolerate multiple calls to shutdown.
 
 ## [2.7.0] - 2021-07-11
 

--- a/tests/test_cancel_on_shutdown.py
+++ b/tests/test_cancel_on_shutdown.py
@@ -76,7 +76,7 @@ def test_submit_during_shutdown():
         assert_that(f, equal_to(futures[2]))
         assert_that(
             calling(executor.submit).with_args(lambda: None),
-            raises(RuntimeError, "Cannot submit after shutdown"),
+            raises(RuntimeError, "cannot schedule new futures after shutdown"),
         )
         submit_more_done[0] = True
 
@@ -103,7 +103,7 @@ def test_submit_during_shutdown_no_deadlock():
         proceed.wait()
         assert_that(
             calling(executor.submit).with_args(lambda: None),
-            raises(RuntimeError, "Cannot submit after shutdown"),
+            raises(RuntimeError, "cannot schedule new futures after shutdown"),
         )
         submit_more_done[0] = True
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -503,6 +503,21 @@ def test_submit_staggered(any_executor, request):
         do_test_submit_staggered(any_executor)
 
 
+def test_double_shutdown(any_executor):
+    """Shutting down an executore more than once is OK."""
+    any_executor.shutdown()
+    any_executor.shutdown()
+
+
+def test_submit_after_shutdown(any_executor):
+    """Submitting after executor shutdown raises an error."""
+    any_executor.shutdown()
+    assert_that(
+        calling(any_executor.submit).with_args(lambda: 123),
+        raises(RuntimeError, "cannot schedule new futures after shutdown"),
+    )
+
+
 def do_test_submit_staggered(executor):
     values = [1, 2, 3]
     expected_results = [2, 4, 6, 2, 4, 6]


### PR DESCRIPTION
Rather than letting the behavior on submit-after-shutdown be
undefined, let's consistently check for and raise on such cases.

Fixes #274.