### PR TITLE
Fix f_proxy eager resolution issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Fix a bug specific to Python 2 where mixing `f_proxy` with other future
+  composition functions such as `f_map` could result in the proxy future being
+  eagerly evaluated.
 
 ## [2.8.0] - 2021-07-14
 

--- a/more_executors/_impl/futures/proxy.py
+++ b/more_executors/_impl/futures/proxy.py
@@ -22,6 +22,10 @@ class ProxyFuture(MapFuture):
         return len(self.__result)
 
     def __getattr__(self, name):
+        if name.startswith("__"):
+            # Do not allow any special properties to trigger resolution
+            # of the future, other than those we've explicitly proxied.
+            raise AttributeError()
         return getattr(self.__result, name)
 
     def __getitem__(self, key):


### PR DESCRIPTION
If f_proxy was mixed with other functions such as f_map, the proxy
future would be eagerly evaluated on python2, causing code to
unexpectedly block. It was caused by the interaction between dir()
and __getattr__.

Fixes #278.