### PR TITLE
Fix an f_proxy error handling edge-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Fix a bug where `f_proxy` may trigger a `RecursionError`, if used with a
+  future raising an `AttributeError`.
 
 ## [2.8.1] - 2021-07-21
 

--- a/tests/futures/test_proxy.py
+++ b/tests/futures/test_proxy.py
@@ -4,7 +4,7 @@ import pytest
 
 
 from more_executors import Executors
-from more_executors.futures import f_return, f_proxy, f_map
+from more_executors.futures import f_return, f_return_error, f_proxy, f_map
 
 
 def test_len():
@@ -165,3 +165,18 @@ def test_map():
         # Let it proceed now.
         sem.release()
         assert f.result() == 123
+
+
+def test_attribute_error():
+    error = AttributeError("quux!")
+    prox = f_proxy(f_return_error(error))
+
+    # I should be able to get the exception normally
+    assert prox.exception() is error
+
+    # If I try to iterate, it should raise the exception
+    with pytest.raises(Exception) as excinfo:
+        iter(prox)
+
+    # The raised exception should be exactly the underlying value
+    assert excinfo.value is error


### PR DESCRIPTION
The way __getattr__ and AttributeError interact meant that we could get
into an infinite recursion situation here, if f_proxy was used together
with a future which genuinely raised AttributeError. Add a branch to
handle that case correctly.

Fixes #312