### PR TITLE
Make f_zip use namedtuple in return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- `f_zip` now uses `namedtuple` return types to improve debuggability of certain
+  error scenarios.
 
 ## [2.8.2] - 2022-02-16
 

--- a/tests/futures/test_zip.py
+++ b/tests/futures/test_zip.py
@@ -6,12 +6,14 @@ from more_executors.futures import f_zip, f_return, f_return_error
 def test_zip_none():
     future = f_zip()
     assert future.result() == ()
+    assert "ZipTuple0" in repr(future)
 
 
 def test_zip_single():
     value = "foobar"
     future = f_zip(f_return(value))
     assert future.result() == (value,)
+    assert "ZipTuple1" in repr(future)
 
 
 def test_zip_two():


### PR DESCRIPTION
This slightly improves debuggability in some error cases, as it will be
possible to determine that a tuple was created by f_zip.

Fixes #317