### PR TITLE
Flatten the more_executors namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ from version 1.20.0 onwards.
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- Flattened the `more_executors` module namespace; all public API may now
+  be imported directly from `more_executors` without specifying a submodule.
 
 ## [2.9.0] - 2022-02-21
 

--- a/docs/reference/asyncio.rst
+++ b/docs/reference/asyncio.rst
@@ -4,7 +4,7 @@ asyncio bridge: ``AsyncioExecutor``
 AsyncioExecutor transforms :mod:`concurrent.futures` futures into
 :mod:`asyncio` futures.
 
-.. autoclass:: more_executors.asyncio.AsyncioExecutor
+.. autoclass:: more_executors.AsyncioExecutor
 
 .. automethod:: more_executors.Executors.with_asyncio(executor, loop=None, logger=None)
 

--- a/docs/reference/base-executors.rst
+++ b/docs/reference/base-executors.rst
@@ -18,7 +18,7 @@ Sync
 SyncExecutor is a base executor which invokes any submitted callables
 immediately in the calling thread.
 
-.. autoclass:: more_executors.sync.SyncExecutor
+.. autoclass:: more_executors.SyncExecutor
    :members:
 
 .. automethod:: more_executors.Executors.sync(logger=None)

--- a/docs/reference/cancel.rst
+++ b/docs/reference/cancel.rst
@@ -4,13 +4,12 @@ Cancellation of futures: ``f_nocancel``, ``CancelOnShutdownExecutor``
 Futures API
 -----------
 
-.. automodule:: more_executors.futures
-   :members: f_nocancel
+.. autofunction:: more_executors.f_nocancel
 
 Executors API
 -------------
 
-.. autoclass:: more_executors.cancel_on_shutdown.CancelOnShutdownExecutor
+.. autoclass:: more_executors.CancelOnShutdownExecutor
    :members:
 
 .. automethod:: more_executors.Executors.with_cancel_on_shutdown(executor, logger=None)

--- a/docs/reference/futures-apply.rst
+++ b/docs/reference/futures-apply.rst
@@ -1,5 +1,4 @@
 Applying functions: ``f_apply``
 ===============================
 
-.. automodule:: more_executors.futures
-   :members: f_apply
+.. autofunction:: more_executors.f_apply

--- a/docs/reference/futures-bool.rst
+++ b/docs/reference/futures-bool.rst
@@ -11,7 +11,7 @@ where possible.
 
 Futures which are no longer needed in order to calculate the output value will
 be canceled. In cases where this is not appropriate, consider wrapping the
-input(s) in :meth:`~more_executors.futures.f_nocancel`.
+input(s) in :meth:`~more_executors.f_nocancel`.
 
 Example
 .......
@@ -44,5 +44,7 @@ value would not be used, we can instead write:
    future = f_or(f_x, f_y, f_nocancel(f_z))
 
 
-.. automodule:: more_executors.futures
-   :members: f_or, f_and
+.. autofunction:: more_executors.f_or
+
+.. autofunction:: more_executors.f_and
+

--- a/docs/reference/futures-create.rst
+++ b/docs/reference/futures-create.rst
@@ -1,5 +1,9 @@
 Creating futures from values: ``f_return*``
 ===========================================
 
-.. automodule:: more_executors.futures
-   :members: f_return, f_return_error, f_return_cancelled
+.. autofunction:: more_executors.f_return
+
+.. autofunction:: more_executors.f_return_error
+
+.. autofunction:: more_executors.f_return_cancelled
+

--- a/docs/reference/futures-lists.rst
+++ b/docs/reference/futures-lists.rst
@@ -1,5 +1,9 @@
 Futures and sequences: ``f_traverse``, ``f_sequence``, ``f_zip``
 ================================================================
 
-.. automodule:: more_executors.futures
-   :members: f_zip, f_sequence, f_traverse
+.. autofunction:: more_executors.f_zip
+
+.. autofunction:: more_executors.f_sequence
+
+.. autofunction:: more_executors.f_traverse
+

--- a/docs/reference/futures-map.rst
+++ b/docs/reference/futures-map.rst
@@ -7,18 +7,20 @@ provided function.
 Futures API
 -----------
 
-.. automodule:: more_executors.futures
-   :members: f_map, f_flat_map
+.. autofunction:: more_executors.f_map
+
+.. autofunction:: more_executors.f_flat_map
+
 
 Executors API
 -------------
 
-.. autoclass:: more_executors.map.MapExecutor
+.. autoclass:: more_executors.MapExecutor
    :members: submit
 
 .. automethod:: more_executors.Executors.with_map(executor, fn=None, error_fn=None, logger=None)
 
 
-.. autoclass:: more_executors.flat_map.FlatMapExecutor
+.. autoclass:: more_executors.FlatMapExecutor
 
 .. automethod:: more_executors.Executors.with_flat_map(executor, fn=None, error_fn=None, logger=None)

--- a/docs/reference/futures-proxy.rst
+++ b/docs/reference/futures-proxy.rst
@@ -66,6 +66,4 @@ blocking coding style without requiring explicit calls to ``.result()``:
     cursor = connection.query(some_sql)
     results = process_results(cursor)
 
-.. automodule:: more_executors.futures
-
-    .. autofunction:: f_proxy(f, timeout=None)
+.. autofunction:: more_executors.f_proxy(f, timeout=None)

--- a/docs/reference/poll.rst
+++ b/docs/reference/poll.rst
@@ -13,12 +13,12 @@ Poll function
 The poll function has the following semantics:
 
 - It's called with a single argument, a list of zero or more
-  :class:`~more_executors.poll.PollDescriptor` objects.
+  :class:`~more_executors.PollDescriptor` objects.
 
 - If the poll function can determine that a particular future should be
   completed, either successfully or in error, it should call the
   :meth:`yield_result` or :meth:`yield_exception` methods on the appropriate
-  :class:`~more_executors.poll.PollDescriptor`.
+  :class:`~more_executors.PollDescriptor`.
 
 - If the poll function raises an exception, all futures depending on that poll
   will fail with that exception.  The poll function will be retried later.
@@ -29,7 +29,7 @@ The poll function has the following semantics:
 .. warning::
 
   The poll function should avoid holding a reference to the corresponding
-  :class:`~more_executors.poll.PollExecutor`. If it holds a reference to the
+  :class:`~more_executors.PollExecutor`. If it holds a reference to the
   executor, invoking :meth:`~concurrent.futures.Executor.shutdown` becomes
   mandatory in order to stop the polling thread.
 
@@ -98,7 +98,7 @@ Two obvious approaches include:
       :mod:`concurrent.futures` cannot be used and different types of
       asynchronous work will be handled inconsistently.
 
-:class:`~more_executors.poll.PollExecutor` bridges the gap between the two
+:class:`~more_executors.PollExecutor` bridges the gap between the two
 approaches.  By providing a custom poll function, the tasks can be monitored
 by one thread efficiently, while at the same time allowing full usage of the
 API provided by `Future` objects.
@@ -172,10 +172,10 @@ like this:
         # ...
 
 
-.. autoclass:: more_executors.poll.PollExecutor
+.. autoclass:: more_executors.PollExecutor
    :members:
 
 .. automethod:: more_executors.Executors.with_poll(executor, poll_fn, cancel_fn=None, default_interval=5.0, logger=None)
 
-.. autoclass:: more_executors.poll.PollDescriptor()
+.. autoclass:: more_executors.PollDescriptor()
    :members:

--- a/docs/reference/retry.rst
+++ b/docs/reference/retry.rst
@@ -3,14 +3,14 @@ Retrying: ``RetryExecutor``
 
 RetryExecutor produces futures which will implicitly retry on error.
 
-.. autoclass:: more_executors.retry.RetryExecutor
+.. autoclass:: more_executors.RetryExecutor
    :members:
 
 .. automethod:: more_executors.Executors.with_retry(executor, retry_policy=None, logger=None)
 
-.. autoclass:: more_executors.retry.RetryPolicy
+.. autoclass:: more_executors.RetryPolicy
    :members:
 
-.. autoclass:: more_executors.retry.ExceptionRetryPolicy(max_attempts, exponent, sleep, max_sleep, exception_base)
+.. autoclass:: more_executors.ExceptionRetryPolicy(max_attempts, exponent, sleep, max_sleep, exception_base)
    :members:
 

--- a/docs/reference/throttle.rst
+++ b/docs/reference/throttle.rst
@@ -3,7 +3,7 @@ Throttling: ``ThrottleExecutor``
 
 ThrottleExecutor limits the number of concurrently executing futures.
 
-.. autoclass:: more_executors.throttle.ThrottleExecutor
+.. autoclass:: more_executors.ThrottleExecutor
    :members:
 
 .. automethod:: more_executors.Executors.with_throttle(executor, count, logger=None)

--- a/docs/reference/timeout.rst
+++ b/docs/reference/timeout.rst
@@ -4,13 +4,13 @@ Timing out futures: ``f_timeout``, ``TimeoutExecutor``
 Futures API
 -----------
 
-.. automodule:: more_executors.futures
-   :members: f_timeout
+.. autofunction:: more_executors.f_timeout
+
 
 Executors API
 -------------
 
-.. autoclass:: more_executors.timeout.TimeoutExecutor
+.. autoclass:: more_executors.TimeoutExecutor
    :members: submit_timeout
 
 .. automethod:: more_executors.Executors.with_timeout(executor, timeout, logger=None)

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -19,7 +19,7 @@ instances which may serve as the basis of `composing executors`_.
         to execute callables in processes.
 
     :meth:`~more_executors.Executors.sync`
-        creates a new :class:`~more_executors.sync.SyncExecutor`
+        creates a new :class:`~more_executors.SyncExecutor`
         to execute callables in the calling thread.
 
 Example:
@@ -88,7 +88,7 @@ attempts).
 
 In this example, an unlimited number of futures may be failed and awaiting
 retries. The throttling in this example has no effect, since a
-:class:`~more_executors.sync.SyncExecutor` is intrinsically throttled to
+:class:`~more_executors.SyncExecutor` is intrinsically throttled to
 a single pending future.
 
 .. _naming executors:
@@ -125,49 +125,49 @@ A series of functions are provided for creating and composing
 may be used standalone, or in conjunction with the Executor
 implementations in ``more-executors``.
 
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| Function                                           | Signature                                                            | Description                          |
-+====================================================+======================================================================+======================================+
-| :meth:`~more_executors.futures.f_return`           | X                                                                    | wrap any value in a future           |
-|                                                    |  ⟶ Future<X>                                                         |                                      |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_return_error`     | `n/a`                                                                | wrap any exception in a future       |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_return_cancelled` | `n/a`                                                                | get a cancelled future               |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_apply`            | Future<fn<A[,B[,...]]⟶R>>, Future<A>[, Future<B>[, ...]]             |                                      |
-|                                                    |   ⟶ Future<R>                                                        | apply a function in the future       |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_or`               | Future<A>[, Future<B>[, ...]]                                        |                                      |
-|                                                    |   ⟶ Future<A|B|...>                                                  | boolean ``OR``                       |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_and`              | Future<A>[, Future<B>[, ...]]                                        |                                      |
-|                                                    |   ⟶ Future<A|B|...>                                                  | boolean ``AND``                      |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_zip`              | Future<A>[, Future<B>[, ...]]                                        |                                      |
-|                                                    |   ⟶ Future<A[, B[, ...]]>                                            | combine futures into a tuple         |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_map`              | Future<A>, fn<A⟶B>                                                   | transform output value of a future   |
-|                                                    |   ⟶ Future<B>                                                        | via a blocking function              |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_flat_map`         | Future<A>, fn<A⟶Future<B>>                                           | transform output value of a future   |
-|                                                    |   ⟶ Future<B>                                                        | via a non-blocking function          |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_traverse`         | fn<A⟶Future<B>>, iterable<A>                                         | run non-blocking function over       |
-|                                                    |   ⟶ Future<list<B>>                                                  | iterable                             |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_sequence`         | list<Future<X>>                                                      | convert list of futures to a future  |
-|                                                    |   ⟶ Future<list<X>>                                                  | of list                              |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_nocancel`         | Future<X>                                                            | make a future unable to be cancelled |
-|                                                    |   ⟶ Future<X>                                                        |                                      |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_proxy`            | Future<X>                                                            | make a future proxy calls to the     |
-|                                                    |   ⟶ Future<X>                                                        | future's result                      |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
-| :meth:`~more_executors.futures.f_timeout`          | Future<X>, float                                                     | make a future cancel itself after a  |
-|                                                    |   ⟶ Future<X>                                                        | timeout has elapsed                  |
-+----------------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| Function                                   | Signature                                                            | Description                          |
++============================================+======================================================================+======================================+
+| :meth:`~more_executors.f_return`           | X                                                                    | wrap any value in a future           |
+|                                            |  ⟶ Future<X>                                                         |                                      |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_return_error`     | `n/a`                                                                | wrap any exception in a future       |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_return_cancelled` | `n/a`                                                                | get a cancelled future               |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_apply`            | Future<fn<A[,B[,...]]⟶R>>, Future<A>[, Future<B>[, ...]]             |                                      |
+|                                            |   ⟶ Future<R>                                                        | apply a function in the future       |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_or`               | Future<A>[, Future<B>[, ...]]                                        |                                      |
+|                                            |   ⟶ Future<A|B|...>                                                  | boolean ``OR``                       |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_and`              | Future<A>[, Future<B>[, ...]]                                        |                                      |
+|                                            |   ⟶ Future<A|B|...>                                                  | boolean ``AND``                      |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_zip`              | Future<A>[, Future<B>[, ...]]                                        |                                      |
+|                                            |   ⟶ Future<A[, B[, ...]]>                                            | combine futures into a tuple         |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_map`              | Future<A>, fn<A⟶B>                                                   | transform output value of a future   |
+|                                            |   ⟶ Future<B>                                                        | via a blocking function              |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_flat_map`         | Future<A>, fn<A⟶Future<B>>                                           | transform output value of a future   |
+|                                            |   ⟶ Future<B>                                                        | via a non-blocking function          |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_traverse`         | fn<A⟶Future<B>>, iterable<A>                                         | run non-blocking function over       |
+|                                            |   ⟶ Future<list<B>>                                                  | iterable                             |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_sequence`         | list<Future<X>>                                                      | convert list of futures to a future  |
+|                                            |   ⟶ Future<list<X>>                                                  | of list                              |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_nocancel`         | Future<X>                                                            | make a future unable to be cancelled |
+|                                            |   ⟶ Future<X>                                                        |                                      |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_proxy`            | Future<X>                                                            | make a future proxy calls to the     |
+|                                            |   ⟶ Future<X>                                                        | future's result                      |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
+| :meth:`~more_executors.f_timeout`          | Future<X>, float                                                     | make a future cancel itself after a  |
+|                                            |   ⟶ Future<X>                                                        | timeout has elapsed                  |
++--------------------------------------------+----------------------------------------------------------------------+--------------------------------------+
 
 
 Usage of threads
@@ -192,7 +192,7 @@ Shutting down an executor will also shut down all wrapped executors.
 
 In the example below, any threads created by the
 :class:`~concurrent.futures.ThreadPoolExecutor`, as well as the thread
-created by the :class:`~more_executors.retry.RetryExecutor`, will be joined
+created by the :class:`~more_executors.RetryExecutor`, will be joined
 at the end of the `with` block:
 
 .. code-block:: python
@@ -225,8 +225,8 @@ Generally, shutting down executors is optional and is not necessary to
 (eventually) reclaim resources.
 
 However, where executors accept caller-provided code (such as the polling
-function to :class:`~more_executors.poll.PollExecutor` or the retry
-policy to :class:`~more_executors.retry.RetryExecutor`), it is easy to
+function to :class:`~more_executors.PollExecutor` or the retry
+policy to :class:`~more_executors.RetryExecutor`), it is easy to
 accidentally create a circular reference between the provided code and the
 executor. When this happens, it will no longer be possible for the garbage
 collector to clean up the executor's resources automatically and a thread
@@ -308,32 +308,32 @@ The following metrics are available:
 
     ``more_executors_retry_total``
         A *counter* for the total number of times a future was retried
-        by :class:`~more_executors.retry.RetryExecutor`.
+        by :class:`~more_executors.RetryExecutor`.
 
     ``more_executors_retry_queue``
         A *gauge* for the current queue size of a
-        :class:`~more_executors.retry.RetryExecutor` (i.e. the
+        :class:`~more_executors.RetryExecutor` (i.e. the
         number of futures currently waiting to retry).
 
     ``more_executors_retry_delay_total``
         A *counter* for the total time (in seconds) spent waiting to
-        retry futures via :class:`~more_executors.retry.RetryExecutor`.
+        retry futures via :class:`~more_executors.RetryExecutor`.
 
     ``more_executors_throttle_queue``
         A *gauge* for the current queue size of a
-        :class:`~more_executors.throttle.ThrottleExecutor` (i.e. the number of futures
+        :class:`~more_executors.ThrottleExecutor` (i.e. the number of futures
         not yet able to start due to throttling).
 
     ``more_executors_timeout_total``
         A *counter* for the total number of futures cancelled due to timeout
-        via :class:`~more_executors.timeout.TimeoutExecutor` or
-        :func:`~more_executors.futures.f_timeout`.
+        via :class:`~more_executors.TimeoutExecutor` or
+        :func:`~more_executors.f_timeout`.
 
         Only successfully cancelled futures are included.
 
     ``more_executors_shutdown_cancel_total``
         A *counter* for the total number of futures cancelled due to executor
-        shutdown via :class:`~more_executors.cancel_on_shutdown.CancelOnShutdownExecutor`.
+        shutdown via :class:`~more_executors.CancelOnShutdownExecutor`.
 
         Only successfully cancelled futures are included.
 

--- a/examples/fetch-urls
+++ b/examples/fetch-urls
@@ -4,8 +4,7 @@ from __future__ import print_function
 import sys
 import requests
 from concurrent.futures import as_completed
-from more_executors import Executors
-from more_executors.retry import RetryPolicy, ExceptionRetryPolicy
+from more_executors import Executors, RetryPolicy, ExceptionRetryPolicy
 
 
 class LoggingRetryPolicy(RetryPolicy):

--- a/more_executors/__init__.py
+++ b/more_executors/__init__.py
@@ -15,5 +15,35 @@ This documentation was built from an unknown revision.
 """
 from ._impl.executors import Executors
 from . import futures
+from . import asyncio
+from . import cancel_on_shutdown
+from . import flat_map
+from . import map  # pylint: disable=redefined-builtin
+from . import poll
+from . import retry
+from . import sync
+from . import throttle
+from . import timeout
+
+from .futures import *
+from .asyncio import *
+from .cancel_on_shutdown import *
+from .flat_map import *
+from .map import *
+from .poll import *
+from .retry import *
+from .sync import *
+from .throttle import *
+from .timeout import *
 
 __all__ = ["Executors", "futures"]
+__all__.extend(futures.__all__)
+__all__.extend(asyncio.__all__)
+__all__.extend(cancel_on_shutdown.__all__)
+__all__.extend(flat_map.__all__)
+__all__.extend(map.__all__)
+__all__.extend(poll.__all__)
+__all__.extend(retry.__all__)
+__all__.extend(sync.__all__)
+__all__.extend(throttle.__all__)
+__all__.extend(timeout.__all__)

--- a/more_executors/__init__.pyi
+++ b/more_executors/__init__.pyi
@@ -1,2 +1,12 @@
-from . import futures as futures
 from ._impl.executors import Executors as Executors
+
+from .futures import *
+from .asyncio import *
+from .cancel_on_shutdown import *
+from .flat_map import *
+from .map import *
+from .poll import *
+from .retry import *
+from .sync import *
+from .throttle import *
+from .timeout import *

--- a/more_executors/_impl/asyncio.py
+++ b/more_executors/_impl/asyncio.py
@@ -1,8 +1,12 @@
 from concurrent.futures import Executor
-import asyncio
 
 from .metrics import metrics
 from .helpers import ShutdownHelper
+
+try:
+    import asyncio
+except Exception:  # pylint: disable=broad-except
+    pass
 
 
 class AsyncioExecutor(Executor):

--- a/more_executors/_impl/cancel_on_shutdown.py
+++ b/more_executors/_impl/cancel_on_shutdown.py
@@ -13,7 +13,7 @@ class CancelOnShutdownExecutor(CanCustomizeBind, Executor):
     futures when the executor is shut down.
 
     This class is useful in conjunction with executors having custom cancel
-    behavior, such as :class:`~more_executors.poll.PollExecutor`.
+    behavior, such as :class:`~more_executors.PollExecutor`.
 
     .. note::
         From Python 3.9 onwards, the standard

--- a/more_executors/_impl/executors.py
+++ b/more_executors/_impl/executors.py
@@ -95,7 +95,7 @@ class Executors(object):
         """Creates a new synchronous executor.
 
         Returns:
-            ~more_executors.sync.SyncExecutor:
+            ~more_executors.SyncExecutor:
                 a new synchronous executor
 
         Submitted functions will be immediately invoked on the calling thread."""
@@ -115,7 +115,7 @@ class Executors(object):
     def with_retry(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.retry.RetryExecutor:
+            ~more_executors.RetryExecutor:
                 a new executor which will retry callables on failure
         """
         return cls._customize(executor, RetryExecutor, *args, **kwargs)
@@ -124,7 +124,7 @@ class Executors(object):
     def with_map(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.map.MapExecutor:
+            ~more_executors.MapExecutor:
                 a new executor which will transform results through the given function
         """
         return cls._customize(executor, MapExecutor, *args, **kwargs)
@@ -133,7 +133,7 @@ class Executors(object):
     def with_flat_map(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.flat_map.FlatMapExecutor:
+            ~more_executors.FlatMapExecutor:
                 a new executor which will transform results through the given
                 :class:`~concurrent.futures.Future`-providing function
 
@@ -145,7 +145,7 @@ class Executors(object):
     def with_poll(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.poll.PollExecutor:
+            ~more_executors.PollExecutor:
                 a new executor which produces polled futures.
 
                 Submitted callables will have their output passed into
@@ -157,7 +157,7 @@ class Executors(object):
     def with_timeout(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.timeout.TimeoutExecutor:
+            ~more_executors.TimeoutExecutor:
                 a new executor which will attempt to cancel any futures if they've
                 not completed within the given timeout.
 
@@ -169,7 +169,7 @@ class Executors(object):
     def with_throttle(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.throttle.ThrottleExecutor:
+            ~more_executors.ThrottleExecutor:
                 a new executor which enforces a limit on the number of concurrently
                 pending futures.
 
@@ -181,7 +181,7 @@ class Executors(object):
     def with_cancel_on_shutdown(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.cancel_on_shutdown.CancelOnShutdownExecutor:
+            ~more_executors.CancelOnShutdownExecutor:
                 a new executor which attempts to cancel any pending futures when
                 the executor is shut down.
         """
@@ -191,7 +191,7 @@ class Executors(object):
     def with_asyncio(cls, executor, *args, **kwargs):
         """
         Returns:
-            ~more_executors.asyncio.AsyncioExecutor:
+            ~more_executors.AsyncioExecutor:
                 a new executor which returns :class:`asyncio.Future` instances
                 rather than :class:`concurrent.futures.Future` instances, i.e. may be used
                 with the `await` keyword and coroutines.

--- a/more_executors/_impl/flat_map.py
+++ b/more_executors/_impl/flat_map.py
@@ -33,7 +33,7 @@ class FlatMapExecutor(MapExecutor):
     """An executor which delegates to another executor while mapping
     output values through given future-producing functions.
 
-    This executor behaves like :class:`~more_executors.map.MapExecutor`,
+    This executor behaves like :class:`~more_executors.MapExecutor`,
     except that the given mapping/error functions must return instances of
     :class:`~concurrent.futures.Future`, and the mapped future is
     flattened into the future returned from this executor.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_install_requires():
 
 setup(
     name="more-executors",
-    version="2.9.0",
+    version="2.10.0",
     author="Rohan McGovern",
     author_email="rohan@mcgovern.id.au",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/futures/bool_utils.py
+++ b/tests/futures/bool_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from more_executors.futures import f_return, f_return_error, f_return_cancelled
+from more_executors import f_return, f_return_error, f_return_cancelled
 
 
 CANCELLED = object()

--- a/tests/futures/test_and.py
+++ b/tests/futures/test_and.py
@@ -1,8 +1,7 @@
 import time
 import pytest
 
-from more_executors import Executors
-from more_executors.futures import f_return, f_and, f_nocancel
+from more_executors import Executors, f_return, f_and, f_nocancel
 from .bool_utils import (
     falsey,
     truthy,

--- a/tests/futures/test_apply.py
+++ b/tests/futures/test_apply.py
@@ -1,4 +1,4 @@
-from more_executors.futures import f_return, f_apply
+from more_executors import f_return, f_apply
 
 
 def mult2(x):

--- a/tests/futures/test_checks.py
+++ b/tests/futures/test_checks.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from more_executors.futures import (
+from more_executors import (
     f_or,
     f_and,
     f_map,

--- a/tests/futures/test_flat_map.py
+++ b/tests/futures/test_flat_map.py
@@ -1,4 +1,4 @@
-from more_executors.futures import f_flat_map, f_return, f_return_error
+from more_executors import f_flat_map, f_return, f_return_error
 
 
 def div10(x):

--- a/tests/futures/test_map.py
+++ b/tests/futures/test_map.py
@@ -1,4 +1,4 @@
-from more_executors.futures import f_map, f_return
+from more_executors import f_map, f_return
 
 
 def div10(x):

--- a/tests/futures/test_nocancel.py
+++ b/tests/futures/test_nocancel.py
@@ -1,6 +1,5 @@
 import time
-from more_executors import Executors
-from more_executors.futures import f_nocancel
+from more_executors import Executors, f_nocancel
 
 
 def delay_then(x, delay=0.01):

--- a/tests/futures/test_or.py
+++ b/tests/futures/test_or.py
@@ -5,8 +5,7 @@ import gc
 
 import pytest
 
-from more_executors import Executors
-from more_executors.futures import f_or, f_nocancel, f_return
+from more_executors import Executors, f_or, f_nocancel, f_return
 from .bool_utils import (
     falsey,
     truthy,

--- a/tests/futures/test_proxy.py
+++ b/tests/futures/test_proxy.py
@@ -3,8 +3,7 @@ from threading import Semaphore
 import pytest
 
 
-from more_executors import Executors
-from more_executors.futures import f_return, f_return_error, f_proxy, f_map
+from more_executors import Executors, f_return, f_return_error, f_proxy, f_map
 
 
 def test_len():

--- a/tests/futures/test_return.py
+++ b/tests/futures/test_return.py
@@ -1,4 +1,4 @@
-from more_executors.futures import f_return, f_return_error
+from more_executors import f_return, f_return_error
 
 
 def test_f_return():

--- a/tests/futures/test_timeout.py
+++ b/tests/futures/test_timeout.py
@@ -1,8 +1,7 @@
 import time
 
 from concurrent.futures import CancelledError
-from more_executors import Executors
-from more_executors.futures import f_timeout, f_nocancel
+from more_executors import Executors, f_timeout, f_nocancel
 
 
 def test_timeout():

--- a/tests/futures/test_traverse.py
+++ b/tests/futures/test_traverse.py
@@ -1,6 +1,6 @@
 import traceback
 
-from more_executors.futures import f_sequence, f_traverse, f_return, f_return_error
+from more_executors import f_sequence, f_traverse, f_return, f_return_error
 
 from ..util import get_traceback
 

--- a/tests/futures/test_zip.py
+++ b/tests/futures/test_zip.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 
-from more_executors.futures import f_zip, f_return, f_return_error
+from more_executors import f_zip, f_return, f_return_error
 
 
 def test_zip_none():

--- a/tests/retry/test_broken_retry.py
+++ b/tests/retry/test_broken_retry.py
@@ -1,5 +1,4 @@
-from more_executors import Executors
-from more_executors.retry import RetryPolicy
+from more_executors import Executors, RetryPolicy
 
 
 def test_broken_policy(caplog):

--- a/tests/retry/test_retry.py
+++ b/tests/retry/test_retry.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     from mock import MagicMock, call
 
-from more_executors.retry import RetryExecutor, ExceptionRetryPolicy, RetryPolicy
+from more_executors import RetryExecutor, ExceptionRetryPolicy, RetryPolicy
 
 from ..util import assert_soon
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -4,8 +4,7 @@ import sys
 import pytest
 from hamcrest import assert_that, equal_to, calling, raises
 
-from more_executors import Executors
-from more_executors.asyncio import AsyncioExecutor
+from more_executors import Executors, AsyncioExecutor
 
 
 @pytest.fixture

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -1,6 +1,5 @@
 from functools import partial
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
+from more_executors import Executors, SyncExecutor
 
 
 def mult2(x):

--- a/tests/test_cancel_on_shutdown.py
+++ b/tests/test_cancel_on_shutdown.py
@@ -11,8 +11,7 @@ from hamcrest import (
     greater_than_or_equal_to,
 )
 
-from more_executors import Executors
-from more_executors.cancel_on_shutdown import CancelOnShutdownExecutor
+from more_executors import Executors, CancelOnShutdownExecutor
 
 
 def test_cancels():

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -23,9 +23,7 @@ from hamcrest import (
 )
 from pytest import fixture, skip
 
-from more_executors.retry import RetryPolicy
-from more_executors import Executors
-from more_executors.futures import f_proxy, f_return
+from more_executors import Executors, RetryPolicy, f_proxy, f_return
 
 from .util import assert_soon, run_or_timeout
 from .logging_util import dump_executor, add_debug_logging

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,9 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from hamcrest import assert_that, instance_of
 
-from more_executors import Executors
-from more_executors.retry import RetryExecutor
-from more_executors.map import MapExecutor
+from more_executors import Executors, RetryExecutor, MapExecutor
 
 
 def test_thread_pool():

--- a/tests/test_flat_map.py
+++ b/tests/test_flat_map.py
@@ -1,8 +1,7 @@
 from pytest import fixture
 from hamcrest import assert_that, equal_to, instance_of, calling, raises
 
-from more_executors import Executors
-from more_executors.flat_map import FlatMapExecutor
+from more_executors import Executors, FlatMapExecutor
 
 
 @fixture

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -3,7 +3,7 @@ import traceback
 from pytest import fixture
 from hamcrest import assert_that, equal_to, instance_of, calling, raises
 
-from more_executors.map import MapExecutor
+from more_executors import MapExecutor
 
 
 @fixture

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -20,7 +20,7 @@ from hamcrest import (
     matches_regexp,
 )
 
-from more_executors.poll import PollExecutor
+from more_executors import PollExecutor
 
 from .util import assert_soon
 

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -3,8 +3,7 @@ import time
 
 from hamcrest import assert_that, less_than_or_equal_to, equal_to, instance_of
 
-from more_executors import Executors
-from more_executors.throttle import ThrottleExecutor
+from more_executors import Executors, ThrottleExecutor
 
 
 def test_throttle():

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,8 +3,7 @@ import time
 from concurrent.futures import CancelledError
 from hamcrest import assert_that, equal_to, calling, raises
 
-from more_executors import Executors
-from more_executors.timeout import TimeoutExecutor
+from more_executors import Executors, TimeoutExecutor
 
 
 TIMEOUT = 0.02

--- a/tests/types/type-examples/futures
+++ b/tests/types/type-examples/futures
@@ -2,7 +2,7 @@
 from concurrent.futures import Future
 from collections.abc import Callable
 from typing import Union, Optional
-from more_executors.futures import *
+from more_executors import *
 
 
 x1: int = f_return(123).result()

--- a/tests/types/type-examples/retry
+++ b/tests/types/type-examples/retry
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors.retry import RetryExecutor, RetryPolicy, ExceptionRetryPolicy
-from more_executors import Executors
+from more_executors import Executors, RetryExecutor, RetryPolicy, ExceptionRetryPolicy
 
 
 for exc in [

--- a/tests/types/type-examples/sync
+++ b/tests/types/type-examples/sync
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
+from more_executors import Executors, SyncExecutor
 
 for sync in [Executors.sync(), SyncExecutor()]:
     with sync as exc:

--- a/tests/types/type-examples/sync-flatmap-flatmap
+++ b/tests/types/type-examples/sync-flatmap-flatmap
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.futures import f_return
+from more_executors import Executors, f_return
 
 
 def fn1(x: int) -> Future[str]:

--- a/tests/types/type-examples/sync-map
+++ b/tests/types/type-examples/sync-map
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
-from more_executors.map import MapExecutor
+from more_executors import Executors, SyncExecutor, MapExecutor
 
 exc1 = Executors.sync().with_map(str)
 exc2 = MapExecutor(SyncExecutor(), str)

--- a/tests/types/type-examples/sync-map-map
+++ b/tests/types/type-examples/sync-map-map
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
-from more_executors.map import MapExecutor
+from more_executors import Executors, SyncExecutor, MapExecutor
 
 
 def fn1(x: int) -> str:

--- a/tests/types/type-examples/sync-map-poll
+++ b/tests/types/type-examples/sync-map-poll
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
-from more_executors.map import MapExecutor
-from more_executors.poll import PollDescriptor, PollExecutor
+from more_executors import (
+    Executors,
+    SyncExecutor,
+    MapExecutor,
+    PollDescriptor,
+    PollExecutor,
+)
 
 
 def poll_to_list(ds: list[PollDescriptor[int, list[int]]]) -> None:

--- a/tests/types/type-examples/sync-poll
+++ b/tests/types/type-examples/sync-poll
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.sync import SyncExecutor
-from more_executors.map import MapExecutor
-from more_executors.poll import PollDescriptor, PollExecutor
+from more_executors import (
+    Executors,
+    SyncExecutor,
+    MapExecutor,
+    PollDescriptor,
+    PollExecutor,
+)
 
 
 def poll_to_str(ds: list[PollDescriptor[int, str]]) -> None:

--- a/tests/types/type-examples/timeout
+++ b/tests/types/type-examples/timeout
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from concurrent.futures import Future
-from more_executors import Executors
-from more_executors.timeout import TimeoutExecutor
+from more_executors import Executors, TimeoutExecutor
 
 for exc in [
     Executors.sync().with_timeout(),


### PR DESCRIPTION
It is no longer required to reference different submodules for different
functionality (e.g. 'from more_executors.futures import f_map' can now
be replaced with 'from more_executors import f_map'). Makes the API a
little more convenient.