### PR TITLE
Flatten outputs for chained boolean operations where possible

### DIFF
--- a/tests/futures/test_or.py
+++ b/tests/futures/test_or.py
@@ -19,6 +19,11 @@ from ..util import assert_in_traceback
 LOG = logging.getLogger("test_or")
 
 
+def delay_then(delay, value):
+    time.sleep(delay)
+    return value
+
+
 cases = [
     [(falsey,), falsey],
     [(truthy,), truthy],
@@ -178,3 +183,23 @@ def test_or_large():
     inputs = [f_return(0) for _ in range(0, 100000)]
 
     assert f_or(*inputs).result() == 0
+
+
+def test_or_chain_true():
+    with Executors.thread_pool() as exec:
+        f = exec.submit(delay_then, 0.4, 123)
+
+        for _ in range(0, 10000):
+            f = f_or(f_return(True), f)
+
+        assert f.result() is True
+
+
+def test_or_chain_false():
+    with Executors.thread_pool() as exec:
+        f = exec.submit(delay_then, 0.4, False)
+
+        for _ in range(0, 10000):
+            f = f_or(f_return(False), f)
+
+        assert f.result() is False


### PR DESCRIPTION
Add special-case handling to flatten the data structure when chaining
multiple AND/OR together; for example, make f_and(f_and(x, y), z)
work approximately in the same way as f_and(x, y, z).

The goal here is to avoid a stack overflow when using a pattern which
can chain a large number of futures. Previously, an overflow could start
to happen if the chain was a few hundred futures deep, since each
future's completion callback would set the result on the next future
which would invoke another completion callback and so on throughout the
chain.

Fixes #320