### PR TITLE
Add a method of disabling prometheus & make it efficient

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -240,7 +240,8 @@ Prometheus metrics
 
 This library automatically collects `Prometheus <https://prometheus.io/>`_
 metrics if the ``prometheus_client`` Python module is available.
-The feature is disabled when this module is not installed.
+The feature is disabled when this module is not installed or if the
+``MORE_EXECUTORS_PROMETHEUS`` environment variable is set to ``0``.
 
 If you want to ensure that ``more-executors`` is installed along with
 all prometheus dependencies, you may request the 'prometheus' extras,


### PR DESCRIPTION
Gathering metrics can have a non-negligible cost in time or memory,
so make it possible to disable. Make the disabled case avoid
installation of a callback.