### PR TITLE
Introduce 'block' parameter to ThrottleExecutor

### DIFF
--- a/more_executors/_impl/throttle.pyi
+++ b/more_executors/_impl/throttle.pyi
@@ -15,6 +15,7 @@ class ThrottleExecutor(ExecutorProtocol):
         count: int | Callable[[], int],
         logger: logging.Logger | None = ...,
         name: str = ...,
+        block: bool = ...,
     ): ...
     def __enter__(self) -> ThrottleExecutor: ...
 
@@ -25,5 +26,6 @@ class TypedThrottleExecutor(TypedExecutorProtocol[A, B]):
         count: int | Callable[[], int],
         logger: logging.Logger | None = ...,
         name: str = ...,
+        block: bool = ...,
     ): ...
     def __enter__(self) -> TypedThrottleExecutor[A, B]: ...

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_install_requires():
 
 setup(
     name="more-executors",
-    version="2.10.1",
+    version="2.11.0",
     author="Rohan McGovern",
     author_email="rohan@mcgovern.id.au",
     packages=find_packages(exclude=["tests", "tests.*"]),

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,3 +1,5 @@
+import pytest
+
 from threading import Lock
 import time
 
@@ -6,7 +8,8 @@ from hamcrest import assert_that, less_than_or_equal_to, equal_to, instance_of
 from more_executors import Executors, ThrottleExecutor
 
 
-def test_throttle():
+@pytest.mark.parametrize("block", [True, False])
+def test_throttle(block):
     THREADS = 8
     COUNT = 3
     samples = []
@@ -27,7 +30,9 @@ def test_throttle():
             running_now.remove(x)
 
     futures = []
-    executor = ThrottleExecutor(Executors.thread_pool(max_workers=THREADS), count=COUNT)
+    executor = ThrottleExecutor(
+        Executors.thread_pool(max_workers=THREADS), count=COUNT, block=block
+    )
     with executor:
         for i in range(0, 1000):
             future = executor.submit(record, i)
@@ -51,6 +56,6 @@ def test_throttle():
 
 def test_with_throttle():
     assert_that(
-        Executors.sync(name="throttle-test").with_throttle(4),
+        Executors.sync(name="throttle-test").with_throttle(4, block=True),
         instance_of(ThrottleExecutor),
     )


### PR DESCRIPTION
Blocks on submit rather than enqueuing. Can be used to constrain
memory usage.