### PR TITLE
Fix InvalidStateError log spam in some cancellation scenarios

### DIFF
--- a/more_executors/_impl/futures/bool.py
+++ b/more_executors/_impl/futures/bool.py
@@ -5,7 +5,7 @@ import logging
 from concurrent.futures import Future
 
 from .base import chain_cancel, weak_callback
-from ..common import copy_future_exception
+from ..common import copy_future_exception, try_set_result
 from .check import ensure_futures
 from ..logwrap import LogWrapper
 from ..metrics import track_future
@@ -44,7 +44,7 @@ class BoolOperation(object):
             (set_result, set_exception, cancel_futures) = self.get_state_update(f)
 
         if set_result:
-            self.out.set_result(f.result())
+            try_set_result(self.out, f.result())
         if set_exception:
             copy_future_exception(f, self.out)
 

--- a/more_executors/_impl/futures/zip.py
+++ b/more_executors/_impl/futures/zip.py
@@ -4,7 +4,10 @@ from threading import Lock
 from functools import partial
 from collections import namedtuple
 
-from more_executors._impl.common import copy_future_exception
+from more_executors._impl.common import (
+    copy_future_exception,
+    try_set_result,
+)
 from .base import f_return, chain_cancel, weak_callback
 from .check import ensure_futures
 from ..metrics import track_future
@@ -67,7 +70,7 @@ class Zipper(object):
         if cancel:
             self.out.cancel()
         if set_result:
-            self.out.set_result(maketuple(self.fs))
+            try_set_result(self.out, maketuple(self.fs))
         if set_exception:
             copy_future_exception(f, self.out)
 

--- a/more_executors/_impl/map.py
+++ b/more_executors/_impl/map.py
@@ -1,6 +1,11 @@
 from concurrent.futures import Executor
 
-from .common import _Future, copy_exception, copy_future_exception
+from .common import (
+    _Future,
+    copy_exception,
+    copy_future_exception,
+    try_set_result,
+)
 from .wrap import CanCustomizeBind
 from .metrics import metrics, track_future
 from .helpers import ShutdownHelper
@@ -71,7 +76,7 @@ class MapFuture(_Future):
             copy_exception(self)
 
     def _on_mapped(self, result):
-        self.set_result(result)
+        try_set_result(self, result)
 
     def set_result(self, result):
         with self._me_lock:

--- a/more_executors/_impl/poll.py
+++ b/more_executors/_impl/poll.py
@@ -5,7 +5,13 @@ import logging
 
 from monotonic import monotonic
 
-from .common import _Future, MAX_TIMEOUT, copy_exception, copy_future_exception
+from .common import (
+    _Future,
+    MAX_TIMEOUT,
+    copy_exception,
+    copy_future_exception,
+    try_set_result,
+)
 from .wrap import CanCustomizeBind
 from .helpers import executor_loop
 from .event import get_event, is_shutdown
@@ -108,8 +114,7 @@ class PollDescriptor(object):
             result (object):
                 a result to be returned by the future associated with this descriptor
         """
-
-        self.__future.set_result(result)
+        try_set_result(self.__future, result)
 
     def yield_exception(self, exception, traceback=None):
         """The poll function can call this function to make the future raise the given exception.


### PR DESCRIPTION
If a future has already been cancelled, we can't set the result or
exception. It is not an error if this happens to a future cancelled by
the caller, so don't generate ERROR logs in that case.

Fixes #337