### PR TITLE
Use time.monotonic on py3.3+

### DIFF
--- a/more_executors/_impl/metrics/__init__.py
+++ b/more_executors/_impl/metrics/__init__.py
@@ -2,7 +2,10 @@ import os
 import logging
 from functools import partial
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 from .null import NullMetrics
 

--- a/more_executors/_impl/poll.py
+++ b/more_executors/_impl/poll.py
@@ -3,7 +3,10 @@ from threading import RLock, Thread
 import weakref
 import logging
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 from .common import (
     _Future,

--- a/more_executors/_impl/retry.py
+++ b/more_executors/_impl/retry.py
@@ -3,7 +3,10 @@ from threading import RLock, Thread
 import logging
 import weakref
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 from .common import _Future, MAX_TIMEOUT, copy_future_exception
 from .wrap import CanCustomizeBind

--- a/more_executors/_impl/timeout.py
+++ b/more_executors/_impl/timeout.py
@@ -4,7 +4,10 @@ from collections import namedtuple
 import weakref
 import logging
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 from .map import MapFuture
 from .common import MAX_TIMEOUT

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 futures; python_version < '3'
 six
-monotonic
+monotonic; python_version < '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,6 @@
 #
 #    pip-compile --generate-hashes requirements.in
 #
-monotonic==1.6 \
-    --hash=sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7 \
-    --hash=sha256:68687e19a14f11f26d140dd5c86f3dba4bf5df58003000ed467e0e2a69bca96c
-    # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/tests/logging_util.py
+++ b/tests/logging_util.py
@@ -5,7 +5,10 @@ import collections
 import pprint
 from threading import Lock
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
 
 
 class CollectionLogger(logging.Logger, object):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,6 +10,7 @@ import sys
 from concurrent.futures import Executor, CancelledError, wait, FIRST_COMPLETED
 
 from six.moves.queue import Queue
+
 try:
     from time import monotonic
 except ImportError:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,7 +10,10 @@ import sys
 from concurrent.futures import Executor, CancelledError, wait, FIRST_COMPLETED
 
 from six.moves.queue import Queue
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:
+    from monotonic import monotonic
 from hamcrest import (
     assert_that,
     equal_to,


### PR DESCRIPTION
On Python 3.3 or newer, `monotonic` module aliases `time.monotonic` from the standard library. On older versions, it will fall back to an equivalent platform specific implementation provided by the `monotonic` module.
Attempting to import `time.monotonic` right off the bat removes the need for additional dependency on modern python installations.