### PR TITLE
Fix sleep_time method in ExceptionRetryPolicy

### DIFF
--- a/more_executors/_impl/retry.py
+++ b/more_executors/_impl/retry.py
@@ -89,7 +89,7 @@ class ExceptionRetryPolicy(RetryPolicy):
         return False
 
     def sleep_time(self, attempt, future):
-        return min(self._sleep * (self._exponent**attempt), self._max_sleep)
+        return min(self._sleep * (self._exponent**(attempt-1)), self._max_sleep)
 
 
 class RetryJob(object):

--- a/more_executors/_impl/retry.py
+++ b/more_executors/_impl/retry.py
@@ -89,7 +89,7 @@ class ExceptionRetryPolicy(RetryPolicy):
         return False
 
     def sleep_time(self, attempt, future):
-        return min(self._sleep * (self._exponent**(attempt-1)), self._max_sleep)
+        return min(self._sleep * (self._exponent ** (attempt - 1)), self._max_sleep)
 
 
 class RetryJob(object):


### PR DESCRIPTION
There is a small discrepancy between documentation and implementation of sleep_time in ExceptionRetryPolicy. We modify the implementation so that it conforms with the docs.