### PR TITLE
Fix compatibility with python 3.12 (get_event_loop)

### DIFF
--- a/more_executors/_impl/asyncio.py
+++ b/more_executors/_impl/asyncio.py
@@ -28,8 +28,14 @@ class AsyncioExecutor(Executor):
                 executor to which callables will be submitted
 
             loop (~asyncio.AbstractEventLoop):
-                asyncio event loop used to wrap futures; if omitted, the default
-                event loop is used.
+                asyncio event loop used to wrap futures; if omitted, the return
+                value of :meth:`asyncio.get_event_loop` is used.
+
+                .. note::
+                    Starting from Python 3.12, :meth:`asyncio.get_event_loop` raises
+                    an exception if there is no current event loop, so it is
+                    necessary to either pass a loop explicitly or ensure there is a
+                    running loop prior to constructing this executor.
 
             logger (~logging.Logger):
                 a logger used for messages from this executor

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -13,7 +13,13 @@ def asyncio():
         pytest.skip("needs python >= 3.5")
     import asyncio
 
-    return asyncio
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    yield asyncio
+
+    loop.close()
+    asyncio.set_event_loop(None)
 
 
 def sleep_then_return(timeout, value):


### PR DESCRIPTION
asyncio.get_event_loop no longer implicitly creates a loop. Fix the tests which relied on this behavior.

This also impacts users of AsyncioExecutor if they relied on implicit loop creation, so mention this in the docs.